### PR TITLE
docs: replace envName with varName in README

### DIFF
--- a/packages/envied/README.md
+++ b/packages/envied/README.md
@@ -52,7 +52,7 @@ part 'env.g.dart'
 
 @Envied()
 abstract class Env {
-    @EnviedField(envName: 'KEY')
+    @EnviedField(varName: 'KEY')
     static const key = _Env.key;
 }
 ```
@@ -116,7 +116,7 @@ part 'env.g.dart';
 
 @Envied(path: '.env.dev')
 abstract class Env {
-    @EnviedField(envName: 'KEY1')
+    @EnviedField(varName: 'KEY1')
     static const key1 = _Env.key1;
     @EnviedField()
     static const KEY2 = _Env.KEY2;


### PR DESCRIPTION
I updated the README to remove the confusion caused by envName.
caused by 199fdfbc79b1f113f47940eb3717559c192632d9

related this #5