### PR TITLE
fix Updated dart version to 4.0.0 for future readiness.

### DIFF
--- a/examples/envied_example/pubspec.yaml
+++ b/examples/envied_example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 
 environment:
-  sdk: '>=2.17.3 <3.0.0'
+  sdk: '>=2.17.3 <4.0.0'
 
 dev_dependencies:
   build_runner: ^2.1.11

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
 environment:
-  sdk: ">=2.17.1 <3.0.0"
+  sdk: ">=2.17.1 <4.0.0"
 
 # dependencies:
 #   path: ^1.8.0

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
 environment:
-  sdk: ">=2.17.1 <3.0.0"
+  sdk: ">=2.17.1 <4.0.0"
 
 dependencies:
   envied: ^0.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,4 +8,4 @@ dev_dependencies:
   yaml: ^3.1.0
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: ">=2.2.2 <4.0.0"


### PR DESCRIPTION
Currently Envied package is failing to generate because of Dart version update from 3.0.0 to 3.1.0 . I have update it to Version 4.0.0 so we don't have to update package again.