### PR TITLE
fix: amend dependencies and bump Dart SDK to ">=2.19.0 <4.0.0"

### DIFF
--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,15 +1,15 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 0.3.0+1
+version: 0.3.0+2
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=2.19.0 <4.0.0"
 
 # dependencies:
 #   path: ^1.8.0
 
 dev_dependencies:
-  lints: ^2.1.0
+  lints: ^2.0.0
   test: ^1.24.2

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,19 +1,19 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 0.3.0+1
+version: 0.3.0+2
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=2.19.0 <4.0.0"
 
 dependencies:
   envied: ^0.3.0+1
   build: ^2.4.0
   source_gen: ^1.3.1
-  analyzer: ^5.12.0
+  analyzer: ^5.11.1
 
 dev_dependencies:
-  lints: ^2.1.0
+  lints: ^2.0.0
   test: ^1.24.2
   source_gen_test: ^1.0.5


### PR DESCRIPTION
* [CHORE] bump Dart SDK to ">=2.19.0 <4.0.0"
* [FIX] downgrade analyzer to ^5.11.1 
* [FIX] downgrade lints to ^2.0.0

- fixes https://github.com/petercinibulk/envied/issues/32
- `lints: ^2.1.0` requires Dart 3.0.0