### PR TITLE
refactor: facelift both Envied and EnviedGenerator to Dart 3.0

### DIFF
--- a/examples/envied_example/.env
+++ b/examples/envied_example/.env
@@ -1,2 +1,5 @@
-KEY1=VALUE1
-KEY2=VALUE2
+KEY1=foo
+KEY2=bar
+key3=baz
+key4=123
+key5=false

--- a/examples/envied_example/.env_debug
+++ b/examples/envied_example/.env_debug
@@ -1,2 +1,5 @@
-KEY1=DEBUG1
-KEY2=DEBUG2
+KEY1=debug_foo
+KEY2=debug_bar
+key3=debug_baz
+key4=456
+key5=true

--- a/examples/envied_example/lib/app_env.dart
+++ b/examples/envied_example/lib/app_env.dart
@@ -2,7 +2,7 @@ import 'app_env_fields.dart';
 import 'debug_env.dart';
 import 'release_env.dart';
 
-abstract class AppEnv implements AppEnvFields {
+abstract interface class AppEnv implements AppEnvFields {
   /// NOTE: This is here just as an example!
   ///
   /// In a Flutter app you would normally import this like so

--- a/examples/envied_example/lib/app_env_fields.dart
+++ b/examples/envied_example/lib/app_env_fields.dart
@@ -1,5 +1,5 @@
 /// Both DebugEnv and ReleaseEnv must implement all these values
-abstract class AppEnvFields {
+abstract interface class AppEnvFields {
   abstract final String key1;
   abstract final String key2;
   abstract final String key3;

--- a/examples/envied_example/lib/debug_env.dart
+++ b/examples/envied_example/lib/debug_env.dart
@@ -6,7 +6,7 @@ import 'app_env_fields.dart';
 part 'debug_env.g.dart';
 
 @Envied(name: 'Env', path: '.env_debug')
-class DebugEnv implements AppEnv, AppEnvFields {
+final class DebugEnv implements AppEnv, AppEnvFields {
   const DebugEnv();
 
   @override

--- a/examples/envied_example/lib/debug_env.g.dart
+++ b/examples/envied_example/lib/debug_env.g.dart
@@ -6,10 +6,10 @@ part of 'debug_env.dart';
 // EnviedGenerator
 // **************************************************************************
 
-class _Env {
-  static const String key1 = 'DEBUG1';
-  static const String key2 = 'DEBUG2';
-  static const String key3 = 'test_';
-  static const int key4 = 0;
+final class _Env {
+  static const String key1 = 'debug_foo';
+  static const String key2 = 'debug_bar';
+  static const String key3 = 'debug_baz';
+  static const int key4 = 456;
   static const bool key5 = true;
 }

--- a/examples/envied_example/lib/env.dart
+++ b/examples/envied_example/lib/env.dart
@@ -4,7 +4,7 @@ import 'package:envied/envied.dart';
 part 'env.g.dart';
 
 @Envied(path: '.env')
-abstract class Env {
+final class Env {
   @EnviedField(varName: 'KEY1')
   static const String key1 = _Env.key1;
   @EnviedField(varName: 'KEY2')

--- a/examples/envied_example/lib/env.dart
+++ b/examples/envied_example/lib/env.dart
@@ -6,9 +6,9 @@ part 'env.g.dart';
 @Envied(path: '.env')
 abstract class Env {
   @EnviedField(varName: 'KEY1')
-  static const key1 = _Env.key1;
+  static const String key1 = _Env.key1;
   @EnviedField(varName: 'KEY2')
-  static const key2 = _Env.key2;
+  static const String key2 = _Env.key2;
   @EnviedField()
   static const String key3 = _Env.key3;
   @EnviedField()

--- a/examples/envied_example/lib/env.g.dart
+++ b/examples/envied_example/lib/env.g.dart
@@ -6,10 +6,10 @@ part of 'env.dart';
 // EnviedGenerator
 // **************************************************************************
 
-class _Env {
-  static const key1 = 'VALUE1';
-  static const key2 = 'VALUE2';
-  static const String key3 = 'test_';
-  static const int key4 = 0;
-  static const bool key5 = true;
+final class _Env {
+  static const String key1 = 'foo';
+  static const String key2 = 'bar';
+  static const String key3 = 'baz';
+  static const int key4 = 123;
+  static const bool key5 = false;
 }

--- a/examples/envied_example/lib/release_env.dart
+++ b/examples/envied_example/lib/release_env.dart
@@ -6,7 +6,7 @@ import 'app_env_fields.dart';
 part 'release_env.g.dart';
 
 @Envied(name: 'Env', path: '.env')
-class ReleaseEnv implements AppEnv, AppEnvFields {
+final class ReleaseEnv implements AppEnv, AppEnvFields {
   const ReleaseEnv();
 
   @override

--- a/examples/envied_example/lib/release_env.g.dart
+++ b/examples/envied_example/lib/release_env.g.dart
@@ -6,10 +6,10 @@ part of 'release_env.dart';
 // EnviedGenerator
 // **************************************************************************
 
-class _Env {
-  static const String key1 = 'VALUE1';
-  static const String key2 = 'VALUE2';
-  static const String key3 = 'test_';
-  static const int key4 = 0;
-  static const bool key5 = true;
+final class _Env {
+  static const String key1 = 'foo';
+  static const String key2 = 'bar';
+  static const String key3 = 'baz';
+  static const int key4 = 123;
+  static const bool key5 = false;
 }

--- a/examples/envied_example/pubspec.lock
+++ b/examples/envied_example/pubspec.lock
@@ -5,26 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "58826e40314219b223f4723dd4205845040161cdc2df3e6a1cdceed5d8165084"
+      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
       url: "https://pub.dev"
     source: hosted
-    version: "63.0.0"
+    version: "61.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f85566ec7b3d25cbea60f7dd4f157c5025f2f19233ca4feeed33b616c78a26a3
+      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "5.13.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: b003c3098049a51720352d219b0bb5f219b60fbfb68e7a4748139a06a5676515
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.2"
   async:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "5bbf32bc9e518d41ec49718e2931cd4527292c9b0c6d2dffcf7fe6b9a8a8cf72"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: f4d6244cc071ba842c296cb1c4ee1b31596b9f924300647ac7a1445493471a3f
+      sha256: "6d6ee4276b1c5f34f21fdf39425202712d2be82019983d52f351c94aafbc2c41"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.3"
+    version: "7.2.10"
   built_collection:
     dependency: transitive
     description:
@@ -101,58 +101,58 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "9334e4d598ea41862dd812f64b6ce959e83afab265e59d3248802c05d7cef109"
+      sha256: "598a2a682e2a7a90f08ba39c0aaa9374c5112340f0a2e275f61b59389543d166"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.3"
+    version: "8.6.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: dd007e4fb8270916820a0d66e24f619266b60773cddd082c6439341645af2659
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "02ce3596b459c666530f045ad6f96209474e8fee6e4855940a3cee65fb872ec5"
+      sha256: "4ad01d6e56db961d29661561effde45e519939fdaeb46c351275b182eac70189"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.5.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: "196284f26f69444b7f5c50692b55ec25da86d9e500451dc09333bf2e3ad69259"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      sha256: "17cf9a839208acaed741b1f00ac87cd1fde00548198ba57205cca45c749cb379"
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.6.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   dart_style:
     dependency: transitive
     description:
@@ -179,18 +179,18 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: b69516f2c26a5bcac4eee2e32512e1a5205ab312b3536c1c1227b2b942b5f9ad
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "7.0.0"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: c51b4fdfee4d281f49b8c957f1add91b815473597f76bcf07377987f66a55729
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   graphs:
     dependency: transitive
     description:
@@ -227,50 +227,50 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: db3060f22889f3d9d55f6a217565486737037eec3609f7f3eca4d0c67ee0d8a0
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "0d4c73c3653ab85bf696d51a9657604c900a370549196a91f33e4c39af760852"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: a5e201311cb08bf3912ebbe9a2be096e182d703f881136ec1e81a2338a9e120d
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "53cddd9d4a2d253d977dbbd21642f20f580a6a65fcc05d9d69b9f0ecc264cad9"
+      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.0"
+    version: "4.8.1"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      sha256: "5cfd6509652ff5e7fe149b6df4859e687fca9048437857cb2e65c8d780f396e3"
+      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: "293ae2d49fd79d4c04944c3a26dfd313382d5f52e821ec57119230ae16031ad4"
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:
@@ -291,18 +291,18 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: dab22e92b41aa1255ea90ddc4bc2feaf35544fd0728e209638cad041a6e3928a
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -315,10 +315,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   pool:
     dependency: transitive
     description:
@@ -331,50 +331,50 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "816c1a640e952d213ddd223b3e7aafae08cd9f8e1f6864eed304cc13b0272b07"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "3686efe4a4613a4449b1a4ae08670aadbd3376f2e78d93e3f8f0919db02a7256"
+      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.3"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: f27c6406c89ab3921ed4a3bbdc38d48676f8b78fe537cbdbeb0d2c0f661026d7
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "6db16374bc3497d21aa0eebe674d3db9fdf82082aac0f04dc7b44e4af5b08afc"
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   source_gen:
     dependency: transitive
     description:
@@ -387,58 +387,58 @@ packages:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "8c463326277f68a628abab20580047b419c2ff66756fd0affd451f73f9508c11"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      sha256: "52de2200bb098de739794c82d09c41ac27b2e42fd7e23cce7b9c74bf653c7296"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: e3320978e3715725e62f04358fd249c1efe5999297b2c6acd626a817593281b0
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: f8d9f247e2f9f90e32d1495ff32dac7e4ae34ffa7194c5ff8fcc0fd0e52df774
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: db47e4797198ee601990820437179bb90219f918962318d494ada2b4b11e6f6d
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: ed464977cb26a1f41537e177e190c67223dbd9f4f683489b6ab2e5d211ec564e
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "862015c5db1f3f3c4ea3b94dc2490363a84262994b88902315ed74be1155612f"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -475,57 +475,57 @@ packages:
     dependency: transitive
     description:
       name: timing
-      sha256: c386d07d7f5efc613479a7c4d9d64b03710b03cfaa7e8ad5f2bfb295a1f0dfad
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: e686ae49284939abc06972e25f634ccdb5007d5664c4dfa1995002e8b6aa27a9
+      sha256: "0fae432c85c4ea880b33b497d32824b97795b04cdaa74d270219572a1f50268d"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.0"
+    version: "11.9.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: e42dfcc48f67618344da967b10f62de57e04bae01d9d3af4c2596f3712a88c99
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "3a969ddcc204a3e34e863d204b29c0752716f78b6f9cc8235083208d268a4ccd"
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      sha256: f66577ed748712574b076e48a300aa3d8bc7aba93e83490c679707187e135ee4
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
 sdks:
   dart: ">=3.0.0 <4.0.0"

--- a/examples/envied_example/pubspec.lock
+++ b/examples/envied_example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "405666cd3cf0ee0a48d21ec67e65406aad2c726d9fa58840d3375e7bdcd32a07"
+      sha256: "58826e40314219b223f4723dd4205845040161cdc2df3e6a1cdceed5d8165084"
       url: "https://pub.dev"
     source: hosted
-    version: "60.0.0"
+    version: "63.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "1952250bd005bacb895a01bf1b4dc00e3ba1c526cf47dca54dfe24979c65f5b3"
+      sha256: f85566ec7b3d25cbea60f7dd4f157c5025f2f19233ca4feeed33b616c78a26a3
       url: "https://pub.dev"
     source: hosted
-    version: "5.12.0"
+    version: "6.1.0"
   args:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "271b8899fc99f9df4f4ed419fa14e2fff392c7b2c162fbb87b222e2e963ddc73"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "43865b79fbb78532e4bff7c33087aa43b1d488c4fdef014eaef568af6d8016dc"
+      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   build_config:
     dependency: transitive
     description:
@@ -69,18 +69,18 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "7c35a3a7868626257d8aee47b51c26b9dba11eaddf3431117ed2744951416aab"
+      sha256: "6c4dd11d05d056e76320b828a1db0fc01ccd376922526f8e9d6c796a5adbac20"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "87e06c939450b9b94e3e1bb2d46e0e9780adbff5500d3969f2ba2de6bbb860cb"
+      sha256: "10c6bcdbf9d049a0b666702cf1cee4ddfdc38f02a19d35ae392863b47519848b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.6"
   build_runner_core:
     dependency: transitive
     description:
@@ -157,24 +157,24 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7a03456c3490394c8e7665890333e91ae8a49be43542b616e414449ac358acd4"
+      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.4"
+    version: "2.3.2"
   envied:
     dependency: "direct main"
     description:
       path: "../../packages/envied"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   envied_generator:
     dependency: "direct dev"
     description:
       path: "../../packages/envied_generator"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   file:
     dependency: transitive
     description:
@@ -195,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "82715f8041a85a534a7bf64400b2ee0bb3d594ccf695d97c0bb017259657ff5d"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.0"
   glob:
     dependency: transitive
     description:
@@ -211,10 +211,10 @@ packages:
     dependency: transitive
     description:
       name: graphs
-      sha256: ae0b3d956ff324c6f8671f08dcb2dbd71c99cdbf2aa3ca63a14190c47aa6679c
+      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.3.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -275,18 +275,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "2e2c34e631f93410daa3ee3410250eadc77ac6befc02a040eda8a123f34e6f5a"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.16"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -379,10 +379,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "378a173055cd1fcd2a36e94bf254786d6812688b5f53b6038a2fd180a5a5e210"
+      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -451,26 +451,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: a5fcd2d25eeadbb6589e80198a47d6a464ba3e2049da473943b8af9797900c2d
+      sha256: "9b0dd8e36af4a5b1569029949d50a52cb2a2a2fdaa20cebb96e6603b9ae241f9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.22.0"
+    version: "1.24.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0ef9755ec6d746951ba0aabe62f874b707690b5ede0fecc818b138fcc9b14888"
+      sha256: "4bef837e56375537055fdbbbf6dd458b1859881f4c7e6da936158f77d61ab265"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.20"
+    version: "0.5.6"
   timing:
     dependency: transitive
     description:
@@ -528,4 +528,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.0.0-134.0.dev <4.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/examples/envied_example/pubspec.yaml
+++ b/examples/envied_example/pubspec.yaml
@@ -1,16 +1,16 @@
 name: example
 description: A sample command-line application.
-version: 1.0.0
+version: 2.0.0
 publish_to: none
 
 
 environment:
-  sdk: '>=2.17.3 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dev_dependencies:
-  build_runner: ^2.1.11
-  envied_generator: ^0.3.0+3
-  lints: ^2.0.0
-  test: ^1.16.0
+  build_runner: ^2.4.6
+  envied_generator: ^0.4.0
+  lints: ^2.1.1
+  test: ^1.24.6
 dependencies:
-  envied: ^0.3.0+3
+  envied: ^0.4.0

--- a/packages/envied/lib/src/envied_base.dart
+++ b/packages/envied/lib/src/envied_base.dart
@@ -1,5 +1,5 @@
 /// Annotation used to specify the class to contain environment variables that will be generated from a `.env` file.
-class Envied {
+final class Envied {
   /// The file path of the `.env` file, relative to the project root, which
   /// will be used to generate environment variables.
   ///
@@ -43,7 +43,7 @@ class Envied {
 }
 
 /// Annotation used to specify an environment variable that should be generated from the `.env` file specified in the [Envied] path parameter.
-class EnviedField {
+final class EnviedField {
   /// The environment variable name specified in the `.env` file to generate for the annotated variable
   final String? varName;
 

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,15 +1,12 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 0.3.0+3
+version: 0.4.0
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
 environment:
-  sdk: ">=2.17.1 <4.0.0"
-
-# dependencies:
-#   path: ^1.8.0
+  sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
-  lints: ^2.0.0
-  test: ^1.16.0
+  lints: ^2.1.1
+  test: ^1.24.6

--- a/packages/envied_generator/lib/builder.dart
+++ b/packages/envied_generator/lib/builder.dart
@@ -6,4 +6,4 @@ import 'package:source_gen/source_gen.dart';
 
 /// Primary builder to build the generated code from the `EnviedGenerator`
 Builder enviedBuilder(BuilderOptions options) =>
-    SharedPartBuilder([EnviedGenerator()], 'envied');
+    SharedPartBuilder([const EnviedGenerator()], 'envied');

--- a/packages/envied_generator/lib/src/generate_line.dart
+++ b/packages/envied_generator/lib/src/generate_line.dart
@@ -16,12 +16,12 @@ String generateLine(FieldElement field, String? value) {
     );
   }
 
-  final type = field.type.getDisplayString(withNullability: false);
+  final String type = field.type.getDisplayString(withNullability: false);
 
-  final parsedValue = ((String t) {
+  Object parseValue(String t) {
     switch (t) {
       case "int":
-        final result = int.tryParse(value);
+        final int? result = int.tryParse(value);
         if (result == null) {
           throw InvalidGenerationSourceError(
             'Type `$t` do not align up to value `$value`.',
@@ -31,7 +31,7 @@ String generateLine(FieldElement field, String? value) {
           return result;
         }
       case "double":
-        final result = double.tryParse(value);
+        final double? result = double.tryParse(value);
         if (result == null) {
           throw InvalidGenerationSourceError(
             'Type `$t` do not align up to value `$value`.',
@@ -41,7 +41,7 @@ String generateLine(FieldElement field, String? value) {
           return result;
         }
       case "num":
-        final result = num.tryParse(value);
+        final num? result = num.tryParse(value);
         if (result == null) {
           throw InvalidGenerationSourceError(
             'Type `$t` do not align up to value `$value`.',
@@ -51,7 +51,7 @@ String generateLine(FieldElement field, String? value) {
           return result;
         }
       case "bool":
-        final lowercaseValue = value.toLowerCase();
+        final String lowercaseValue = value.toLowerCase();
         if (['true', 'false'].contains(lowercaseValue)) {
           return lowercaseValue;
         } else {
@@ -69,7 +69,9 @@ String generateLine(FieldElement field, String? value) {
           element: field,
         );
     }
-  })(type);
+  }
+
+  final Object parsedValue = parseValue(type);
 
   return 'static const ${type != 'dynamic' ? type : ''} ${field.name} = $parsedValue;';
 }

--- a/packages/envied_generator/lib/src/generate_line_encrypted.dart
+++ b/packages/envied_generator/lib/src/generate_line_encrypted.dart
@@ -18,31 +18,31 @@ String generateLineEncrypted(FieldElement field, String? value) {
     );
   }
 
-  final rand = Random.secure();
-  final type = field.type.getDisplayString(withNullability: false);
-  final name = field.name;
-  final keyName = '_enviedkey$name';
+  final Random rand = Random.secure();
+  final String type = field.type.getDisplayString(withNullability: false);
+  final String name = field.name;
+  final String keyName = '_enviedkey$name';
 
   switch (type) {
     case "int":
-      final parsed = int.tryParse(value);
+      final int? parsed = int.tryParse(value);
       if (parsed == null) {
         throw InvalidGenerationSourceError(
           'Type `$type` does not align up to value `$value`.',
           element: field,
         );
       } else {
-        final key = rand.nextInt(1 << 32);
-        final encValue = parsed ^ key;
+        final int key = rand.nextInt(1 << 32);
+        final int encValue = parsed ^ key;
         return 'static final int $keyName = $key;\n'
             'static final int $name = $keyName ^ $encValue;';
       }
     case "bool":
-      final lowercaseValue = value.toLowerCase();
+      final String lowercaseValue = value.toLowerCase();
       if (['true', 'false'].contains(lowercaseValue)) {
-        final parsed = lowercaseValue == 'true';
-        final key = rand.nextBool();
-        final encValue = parsed ^ key;
+        final bool parsed = lowercaseValue == 'true';
+        final bool key = rand.nextBool();
+        final bool encValue = parsed ^ key;
         return 'static final bool $keyName = $key;\n'
             'static final bool $name = $keyName ^ $encValue;';
       } else {
@@ -53,14 +53,15 @@ String generateLineEncrypted(FieldElement field, String? value) {
       }
     case "String":
     case "dynamic":
-      final parsed = value.codeUnits;
-      final key = parsed.map((e) => rand.nextInt(1 << 32)).toList(
+      final List<int> parsed = value.codeUnits;
+      final List<int> key = parsed.map((e) => rand.nextInt(1 << 32)).toList(
             growable: false,
           );
-      final encValue = List.generate(parsed.length, (i) => i, growable: false)
-          .map((i) => parsed[i] ^ key[i])
-          .toList(growable: false);
-      final encName = '_envieddata$name';
+      final List<int> encValue =
+          List.generate(parsed.length, (i) => i, growable: false)
+              .map((i) => parsed[i] ^ key[i])
+              .toList(growable: false);
+      final String encName = '_envieddata$name';
       return 'static const List<int> $keyName = [${key.join(", ")}];\n'
           'static const List<int> $encName = [${encValue.join(", ")}];\n'
           'static final ${type == 'dynamic' ? '' : 'String'} $name = String.fromCharCodes(\n'

--- a/packages/envied_generator/lib/src/generator.dart
+++ b/packages/envied_generator/lib/src/generator.dart
@@ -13,7 +13,9 @@ import 'package:source_gen/source_gen.dart';
 ///
 /// Will throw an [InvalidGenerationSourceError] if the annotated
 /// element is not a [classElement].
-class EnviedGenerator extends GeneratorForAnnotation<Envied> {
+final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
+  const EnviedGenerator();
+
   @override
   Future<String> generateForAnnotatedElement(
     Element element,
@@ -81,7 +83,7 @@ class EnviedGenerator extends GeneratorForAnnotation<Envied> {
     });
 
     return '''
-    class _${config.name ?? enviedEl.name} {
+    final class _${config.name ?? enviedEl.name} {
       ${lines.toList().join()}
     }
     ''';

--- a/packages/envied_generator/lib/src/generator.dart
+++ b/packages/envied_generator/lib/src/generator.dart
@@ -22,7 +22,7 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
-    Element enviedEl = element;
+    final Element enviedEl = element;
     if (enviedEl is! ClassElement) {
       throw InvalidGenerationSourceError(
         '`@Envied` can only be used on classes.',
@@ -30,7 +30,7 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
       );
     }
 
-    final config = Envied(
+    final Envied config = Envied(
       path: annotation.read('path').literalValue as String?,
       requireEnvFile:
           annotation.read('requireEnvFile').literalValue as bool? ?? false,
@@ -38,48 +38,51 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
       obfuscate: annotation.read('obfuscate').literalValue as bool,
     );
 
-    final envs = await loadEnvs(config.path, (error) {
-      if (config.requireEnvFile) {
-        throw InvalidGenerationSourceError(
-          error,
-          element: enviedEl,
-        );
-      }
-    });
+    final Map<String, String> envs = await loadEnvs(
+      config.path,
+      (String error) {
+        if (config.requireEnvFile) {
+          throw InvalidGenerationSourceError(
+            error,
+            element: enviedEl,
+          );
+        }
+      },
+    );
 
-    TypeChecker enviedFieldChecker = TypeChecker.fromRuntime(EnviedField);
+    final TypeChecker enviedFieldChecker = TypeChecker.fromRuntime(EnviedField);
 
-    final lines = enviedEl.fields.map((fieldEl) {
+    final Iterable<String> lines = enviedEl.fields.map((FieldElement fieldEl) {
       if (enviedFieldChecker.hasAnnotationOf(fieldEl)) {
-        DartObject? dartObject = enviedFieldChecker.firstAnnotationOf(fieldEl);
-        ConstantReader reader = ConstantReader(dartObject);
+        final DartObject? dartObject =
+            enviedFieldChecker.firstAnnotationOf(fieldEl);
+        final ConstantReader reader = ConstantReader(dartObject);
 
-        String varName =
+        final String varName =
             reader.read('varName').literalValue as String? ?? fieldEl.name;
 
-        Object? defaultValue = reader.read('defaultValue').literalValue;
+        final Object? defaultValue = reader.read('defaultValue').literalValue;
 
-        String? varValue;
+        late final String? varValue;
         if (envs.containsKey(varName)) {
           varValue = envs[varName];
         } else if (Platform.environment.containsKey(varName)) {
           varValue = Platform.environment[varName];
         } else {
-          if (defaultValue != null) {
-            varValue = defaultValue.toString();
-          }
+          varValue = defaultValue?.toString();
         }
 
         final bool obfuscate =
             reader.read('obfuscate').literalValue as bool? ?? config.obfuscate;
 
-        return (obfuscate ? generateLineEncrypted : generateLine)(
-          fieldEl,
-          varValue,
-        );
-      } else {
-        return '';
+        if (obfuscate) {
+          return generateLineEncrypted(fieldEl, varValue);
+        }
+
+        return generateLine(fieldEl, varValue);
       }
+
+      return '';
     });
 
     return '''

--- a/packages/envied_generator/lib/src/load_envs.dart
+++ b/packages/envied_generator/lib/src/load_envs.dart
@@ -11,7 +11,6 @@ Future<Map<String, String>> loadEnvs(
   String path,
   Function(String) onError,
 ) async {
-  const parser = Parser();
   final file = File.fromUri(Uri.file(path));
 
   var lines = <String>[];
@@ -21,6 +20,5 @@ Future<Map<String, String>> loadEnvs(
     onError("Environment variable file doesn't exist at `$path`.");
   }
 
-  final envs = parser.parse(lines);
-  return envs;
+  return Parser.parse(lines);
 }

--- a/packages/envied_generator/lib/src/load_envs.dart
+++ b/packages/envied_generator/lib/src/load_envs.dart
@@ -11,11 +11,11 @@ Future<Map<String, String>> loadEnvs(
   String path,
   Function(String) onError,
 ) async {
-  final file = File.fromUri(Uri.file(path));
+  final File file = File.fromUri(Uri.file(path));
 
-  var lines = <String>[];
+  final List<String> lines = [];
   if (await file.exists()) {
-    lines = await file.readAsLines();
+    lines.addAll(await file.readAsLines());
   } else {
     onError("Environment variable file doesn't exist at `$path`.");
   }

--- a/packages/envied_generator/lib/src/parser.dart
+++ b/packages/envied_generator/lib/src/parser.dart
@@ -1,6 +1,6 @@
 /// Creates key-value pairs from strings formatted as environment
 /// variable definitions.
-class Parser {
+final class Parser {
   static const _singleQuot = "'";
   static final _leadingExport = RegExp(r'''^ *export ?''');
   static final _comment = RegExp(r'''#[^'"]*$''');
@@ -13,7 +13,7 @@ class Parser {
 
   /// Creates a [Map](dart:core).
   /// Duplicate keys are silently discarded.
-  Map<String, String> parse(Iterable<String> lines) {
+  static Map<String, String> parse(Iterable<String> lines) {
     var out = <String, String>{};
     for (var line in lines) {
       var kv = parseOne(line, env: out);
@@ -24,7 +24,7 @@ class Parser {
   }
 
   /// Parses a single line into a key-value pair.
-  Map<String, String> parseOne(String line,
+  static Map<String, String> parseOne(String line,
       {Map<String, String> env = const {}}) {
     var stripped = strip(line);
     if (!_isValid(stripped)) return {};
@@ -49,7 +49,7 @@ class Parser {
   }
 
   /// Substitutes $bash_vars in [val] with values from [env].
-  String interpolate(String val, Map<String, String?> env) =>
+  static String interpolate(String val, Map<String, String?> env) =>
       val.replaceAllMapped(_bashVar, (m) {
         if ((m.group(1) ?? "") == "\\") {
           return m.input.substring(m.start, m.end);
@@ -62,13 +62,13 @@ class Parser {
 
   /// If [val] is wrapped in single or double quotes, returns the quote character.
   /// Otherwise, returns the empty string.
-  String surroundingQuote(String val) {
+  static String surroundingQuote(String val) {
     if (!_surroundQuotes.hasMatch(val)) return '';
     return _surroundQuotes.firstMatch(val)!.group(1)!;
   }
 
   /// Removes quotes (single or double) surrounding a value.
-  String unquote(String val) {
+  static String unquote(String val) {
     if (!_surroundQuotes.hasMatch(val)) {
       return strip(val, includeQuotes: true).trim();
     }
@@ -76,15 +76,15 @@ class Parser {
   }
 
   /// Strips comments (trailing or whole-line).
-  String strip(String line, {bool includeQuotes = false}) =>
+  static String strip(String line, {bool includeQuotes = false}) =>
       line.replaceAll(includeQuotes ? _commentWithQuotes : _comment, '').trim();
 
   /// Omits 'export' keyword.
-  String swallow(String line) => line.replaceAll(_leadingExport, '').trim();
+  static String swallow(String line) => line.replaceAll(_leadingExport, '').trim();
 
-  bool _isValid(String s) => s.isNotEmpty && s.contains('=');
+  static bool _isValid(String s) => s.isNotEmpty && s.contains('=');
 
   /// [ null ] is a valid value in a Dart map, but the env var representation is empty string, not the string 'null'
-  bool _has(Map<String, String?> map, String key) =>
+  static bool _has(Map<String, String?> map, String key) =>
       map.containsKey(key) && map[key] != null;
 }

--- a/packages/envied_generator/lib/src/parser.dart
+++ b/packages/envied_generator/lib/src/parser.dart
@@ -1,42 +1,43 @@
 /// Creates key-value pairs from strings formatted as environment
 /// variable definitions.
 final class Parser {
-  static const _singleQuot = "'";
-  static final _leadingExport = RegExp(r'''^ *export ?''');
-  static final _comment = RegExp(r'''#[^'"]*$''');
-  static final _commentWithQuotes = RegExp(r'''#.*$''');
-  static final _surroundQuotes = RegExp(r'''^(["'])(.*?[^\\])\1''');
-  static final _bashVar = RegExp(r'''(\\)?(\$)(?:{)?([a-zA-Z_][\w]*)+(?:})?''');
-
-  /// [Parser] methods are pure functions.
-  const Parser();
+  static const String _singleQuot = "'";
+  static final RegExp _leadingExport = RegExp(r'''^ *export ?''');
+  static final RegExp _comment = RegExp(r'''#[^'"]*$''');
+  static final RegExp _commentWithQuotes = RegExp(r'''#.*$''');
+  static final RegExp _surroundQuotes = RegExp(r'''^(["'])(.*?[^\\])\1''');
+  static final RegExp _bashVar =
+      RegExp(r'''(\\)?(\$)(?:{)?([a-zA-Z_][\w]*)+(?:})?''');
 
   /// Creates a [Map](dart:core).
   /// Duplicate keys are silently discarded.
   static Map<String, String> parse(Iterable<String> lines) {
-    var out = <String, String>{};
-    for (var line in lines) {
-      var kv = parseOne(line, env: out);
-      if (kv.isEmpty) continue;
-      out.putIfAbsent(kv.keys.single, () => kv.values.single);
+    final Map<String, String> out = {};
+    for (final String line in lines) {
+      final Map<String, String> kv = parseOne(line, env: out);
+      if (kv.isNotEmpty) {
+        out.putIfAbsent(kv.keys.single, () => kv.values.single);
+      }
     }
     return out;
   }
 
   /// Parses a single line into a key-value pair.
-  static Map<String, String> parseOne(String line,
-      {Map<String, String> env = const {}}) {
-    var stripped = strip(line);
+  static Map<String, String> parseOne(
+    String line, {
+    Map<String, String> env = const {},
+  }) {
+    final String stripped = strip(line);
     if (!_isValid(stripped)) return {};
 
-    var idx = stripped.indexOf('=');
-    var lhs = stripped.substring(0, idx);
-    var k = swallow(lhs);
+    final int idx = stripped.indexOf('=');
+    final String lhs = stripped.substring(0, idx);
+    final String k = swallow(lhs);
     if (k.isEmpty) return {};
 
-    var rhs = stripped.substring(idx + 1, stripped.length).trim();
-    var quotChar = surroundingQuote(rhs);
-    var v = unquote(rhs);
+    final String rhs = stripped.substring(idx + 1, stripped.length).trim();
+    final String quotChar = surroundingQuote(rhs);
+    String v = unquote(rhs);
     if (quotChar == _singleQuot) {
       v = v.replaceAll("\\'", "'");
       return {k: v};
@@ -44,43 +45,43 @@ final class Parser {
     if (quotChar == '"') {
       v = v.replaceAll('\\"', '"').replaceAll('\\n', '\n');
     }
-    final interpolatedValue = interpolate(v, env).replaceAll("\\\$", "\$");
+    final String interpolatedValue =
+        interpolate(v, env).replaceAll("\\\$", "\$");
     return {k: interpolatedValue};
   }
 
   /// Substitutes $bash_vars in [val] with values from [env].
   static String interpolate(String val, Map<String, String?> env) =>
-      val.replaceAllMapped(_bashVar, (m) {
+      val.replaceAllMapped(_bashVar, (Match m) {
         if ((m.group(1) ?? "") == "\\") {
           return m.input.substring(m.start, m.end);
         } else {
-          var k = m.group(3)!;
-          if (!_has(env, k)) return '';
-          return env[k]!;
+          final String k = m.group(3)!;
+          return _has(env, k) ? env[k]! : '';
         }
       });
 
   /// If [val] is wrapped in single or double quotes, returns the quote character.
   /// Otherwise, returns the empty string.
-  static String surroundingQuote(String val) {
-    if (!_surroundQuotes.hasMatch(val)) return '';
-    return _surroundQuotes.firstMatch(val)!.group(1)!;
-  }
+  static String surroundingQuote(String val) => _surroundQuotes.hasMatch(val)
+      ? _surroundQuotes.firstMatch(val)!.group(1)!
+      : '';
 
   /// Removes quotes (single or double) surrounding a value.
-  static String unquote(String val) {
-    if (!_surroundQuotes.hasMatch(val)) {
-      return strip(val, includeQuotes: true).trim();
-    }
-    return _surroundQuotes.firstMatch(val)!.group(2)!;
-  }
+  static String unquote(String val) => _surroundQuotes.hasMatch(val)
+      ? _surroundQuotes.firstMatch(val)!.group(2)!
+      : strip(val, includeQuotes: true).trim();
 
   /// Strips comments (trailing or whole-line).
-  static String strip(String line, {bool includeQuotes = false}) =>
+  static String strip(
+    String line, {
+    bool includeQuotes = false,
+  }) =>
       line.replaceAll(includeQuotes ? _commentWithQuotes : _comment, '').trim();
 
   /// Omits 'export' keyword.
-  static String swallow(String line) => line.replaceAll(_leadingExport, '').trim();
+  static String swallow(String line) =>
+      line.replaceAll(_leadingExport, '').trim();
 
   static bool _isValid(String s) => s.isNotEmpty && s.contains('=');
 

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,19 +1,19 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 0.3.0+3
+version: 0.4.0
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
 environment:
-  sdk: ">=2.17.1 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  envied: ^0.3.0+3
-  build: ^2.3.0
-  source_gen: ^1.2.2
-  analyzer: ^5.1.0
+  envied: ^0.4.0
+  build: ^2.4.1
+  source_gen: ^1.4.0
+  analyzer: ^5.12.0
 
 dev_dependencies:
-  lints: ^2.0.0
-  test: ^1.16.0
-  source_gen_test: ^1.0.3
+  lints: ^2.1.1
+  test: ^1.24.6
+  source_gen_test: ^1.0.6

--- a/packages/envied_generator/test/src/generator_tests.dart
+++ b/packages/envied_generator/test/src/generator_tests.dart
@@ -54,7 +54,7 @@ abstract class Env7 {
 }
 
 @ShouldGenerate('''
-class _Env8 {
+final class _Env8 {
   static const String testString = 'testString';
   static const int testInt = 123;
   static const double testDouble = 1.23;
@@ -77,7 +77,7 @@ abstract class Env8 {
 }
 
 @ShouldGenerate('''
-class _Env9 {
+final class _Env9 {
   static const String testString = 'test_string';
 }
 ''')
@@ -88,7 +88,7 @@ abstract class Env9 {
 }
 
 @ShouldGenerate('''
-class _Env10 {
+final class _Env10 {
   static const String systemVar = 'system_var';
 }
 ''')
@@ -99,7 +99,7 @@ abstract class Env10 {
 }
 
 @ShouldGenerate('''
-class _Foo {
+final class _Foo {
   static const String testString = 'test_string';
 }
 ''')
@@ -147,7 +147,7 @@ abstract class Env14 {
 }
 
 @ShouldGenerate('''
-class _Env15 {
+final class _Env15 {
   static const String testDefaultParam = 'test_';
   static const String testString = 'testString';
   static const int testInt = 123;
@@ -173,7 +173,7 @@ abstract class Env15 {
 }
 
 @ShouldGenerate('''
-class _Env16 {
+final class _Env16 {
   static const String testDefaultParam = 'test_';
 }
 ''')

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: c372bb384f273f0c2a8aaaa226dad84dc27c8519a691b888725dec59518ad53a
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   async:
     dependency: transitive
     description:
@@ -53,18 +53,18 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: "66f86e916d285c1a93d3b79587d94bd71984a66aac4ff74e524cfa7877f1395c"
+      sha256: b8db3080e59b2503ca9e7922c3df2072cf13992354d5e944074ffa836fba43b7
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5"
+    version: "0.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ef7e3a5529178ce8f37a9d0b11cbbc8b1e025940f9cf9f76c42da6796301219d
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   conventional_commit:
     dependency: transitive
     description:
@@ -85,26 +85,26 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      sha256: "772db3d53d23361d4ffcf5a9bb091cf3ee9b22f2be52cd107cd7a2683a89ba0e"
+      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.1.0"
   http_parser:
     dependency: transitive
     description:
@@ -133,18 +133,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   melos:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "993ac467e7a36bd832a6cdabbe18a0487c30bc52b5cca14e476a824679ebdce0"
+      sha256: "3f22f6cc629d72acf3acc8a7f8563384550290fa30790efa328c9cf606aa17d7"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.1"
   meta:
     dependency: transitive
     description:
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: pub_updater
-      sha256: "42890302ab2672adf567dc2b20e55b4ecc29d7e19c63b6b98143ab68dd717d3a"
+      sha256: b06600619c8c219065a548f8f7c192b3e080beff95488ed692780f48f69c0625
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.4"
+    version: "0.3.1"
   pubspec:
     dependency: transitive
     description:
@@ -237,34 +237,34 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: e3320978e3715725e62f04358fd249c1efe5999297b2c6acd626a817593281b0
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "862015c5db1f3f3c4ea3b94dc2490363a84262994b88902315ed74be1155612f"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -277,10 +277,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: daadc9baabec998b062c9091525aa95786508b1c48e9c30f1f891b8bf6ff2e64
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
@@ -314,4 +314,4 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=2.19.0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,10 @@
 name: "envied_monorepo"
 publish_to: none
 
-executables:
-
 dev_dependencies:
-  melos: ^3.0.1
+  melos: ^3.1.1
   path: ^1.8.3
   yaml: ^3.1.2
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
- bump the version to `0.4.0`
- raise Dart SDK minimum to 3.0.0
- update dependencies (except analyzer)
- add a `const` constructor to the `EnviedGenerator`
- add the [final Dart 3 class modifier](https://dart.dev/language/class-modifiers#final) `Envied`, `EnviedField`, `EnviedGenerator` and `Parser`
- declare all the `Parser` methods as `static`
- refactor the generator by:
  - adding explicit types
  - explicitly declaring nested functions
  - converting all immutable `var` variables to `final`
- generate all `_Env` classes with the [final Dart 3 class modifier](https://dart.dev/language/class-modifiers#final), i.e.
  ```dart
  final class _Env16 {
    static const String testDefaultParam = 'test_';
  }
  ```
- update example