### PR TITLE
chore: allow usage of analyzer v6

### DIFF
--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   envied: ^0.3.0+3
   build: ^2.3.0
   source_gen: ^1.2.2
-  analyzer: ^5.1.0
+  analyzer: ">=5.1.0 <7.0.0"
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
Since more and more packages are gonna bump their analyzer to v6, I thought it would be wise to gracefully update the version using

```yaml
analyzer: ">=5.1.0 <7.0.0"
```

This won't break older apps and will allow newer ones to use the package without any issues.