### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
   pull_request:
+  workflow_call:
+    inputs:
+      upload_coverage:
+        description: "Upload coverage to codecov"
+        type: boolean
+        required: false
+        default: false
 defaults:
   run:
     shell: bash
@@ -35,7 +42,7 @@ jobs:
       - name: Run coverage
         run: melos run lcov
       - name: Upload Coverage
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_call' && inputs.upload_coverage == true) }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,8 +69,8 @@ jobs:
       - id: create_release
         uses: softprops/action-gh-release@v1
         with:
-          name: ${{ env.VERSION }}
-          tag_name: v${{ env.VERSION }}
+          name: ${{ format('{0}-v{1}', matrix.package, env.VERSION) }}
+          tag_name: ${{ format('{0}-v{1}', matrix.package, env.VERSION) }}
           body_path: ${{ env.CHANGELOG_PATH }}
       - id: cleanup
         if: ${{ always() }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,16 @@ jobs:
             echo "CHANGELOG.md does not contain a section for $VERSION"
             exit 1
           fi
+      - id: validate_pub_dev_topics
+        run: |
+          set -e
+          pattern="^[a-z][a-z0-9-]*[a-z0-9]$"
+          for topic in $(yq -r '.topics[]' pubspec.yaml); do
+            if [[ ! $topic =~ $pattern ]]; then
+              echo "Invalid topic: $topic"
+              exit 1
+            fi
+          done
       - name: Create tag-specific CHANGELOG
         id: create_changelog
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,10 @@
-name: Publish package
+name: Publish
 
 on:
   push:
     tags:
       - 'envied-v[0-9]+.[0-9]+.[0-9]+*'
       - 'envied_generator-v[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
-    branches:
-      - 'release/**'
 defaults:
   run:
     shell: bash
@@ -17,7 +14,7 @@ permissions: read-all
 
 jobs:
   test:
-    uses: ./.github/workflows/main.yml
+    uses: ./.github/workflows/test.yml
     with:
       upload_coverage: false
   publish:
@@ -66,17 +63,10 @@ jobs:
       - id: dependencies
         run: dart pub get
       - id: publish_dry_run
-        if: ${{ github.event_name == 'pull_request' && startsWith(github.ref_name, 'release/') }}
-        run: |
-          set -e
-          dart pub publish --dry-run
+        run: dart pub publish --dry-run
       - id: publish
-        if: ${{ github.event_name == 'push' && startsWith(github.ref_name, format('refs/tags/{0}', matrix.package)) }}
-        run: |
-          set -e
-          dart pub publish --force
+        run: dart pub publish --force
       - id: create_release
-        if: ${{ steps.publish.conclusion == 'success' }}
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ env.VERSION }}
@@ -84,5 +74,4 @@ jobs:
           body_path: ${{ env.CHANGELOG_PATH }}
       - id: cleanup
         if: ${{ always() }}
-        run: |
-          rm -rf $CHANGELOG_PATH
+        run: rm -rf $CHANGELOG_PATH

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,6 @@ defaults:
     shell: bash
 env:
   PUB_ENVIRONMENT: bot.github
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 permissions: read-all
 
 jobs:
@@ -66,14 +65,6 @@ jobs:
           echo "CHANGELOG_PATH=$CHANGELOG_PATH" >> $GITHUB_ENV
       - id: dependencies
         run: dart pub get
-      - id: check_if_dry_run
-        run: |
-          set -e
-          if [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$BRANCH_NAME" == "release/"* ]]; then
-            echo "DRY_RUN=true" >> $GITHUB_ENV
-          else
-            echo "DRY_RUN=false" >> $GITHUB_ENV
-          fi
       - id: publish_dry_run
         if: ${{ github.event_name == 'pull_request' && startsWith(github.ref_name, 'release/') }}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ format('{0}-v{1}', matrix.package, env.VERSION) }}
-          tag_name: ${{ format('{0}-v{1}', matrix.package, env.VERSION) }}
           body_path: ${{ env.CHANGELOG_PATH }}
       - id: cleanup
         if: ${{ always() }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,97 @@
+name: Publish package
+
+on:
+  push:
+    tags:
+      - 'envied-v[0-9]+.[0-9]+.[0-9]+*'
+      - 'envied_generator-v[0-9]+.[0-9]+.[0-9]+*'
+  pull_request:
+    branches:
+      - 'release/**'
+defaults:
+  run:
+    shell: bash
+env:
+  PUB_ENVIRONMENT: bot.github
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/main.yml
+    with:
+      upload_coverage: false
+  publish:
+    needs: test
+    name: "Publish"
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    environment: pub.dev # @petercinibulk needs to be added in the repo environment settings + configured on https://pub.dev
+    strategy:
+      matrix:
+        package: [ envied, envied_generator ]
+      fail-fast: true
+      max-parallel: 1
+    if: ${{ startsWith(github.ref, format('refs/tags/{0}', matrix.package) ) }}
+    defaults:
+      run:
+        working-directory: packages/${{ matrix.package }}
+    steps:
+      - id: setup_dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v3
+      - id: read_version_from_pubspec
+        run: |
+          set -e
+          VERSION=$(yq -r '.version' pubspec.yaml)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - id: check_changelog
+        run: |
+          set -e
+          if ! grep -q "## $VERSION" CHANGELOG.md; then
+            echo "CHANGELOG.md does not contain a section for $VERSION"
+            exit 1
+          fi
+      - name: Create tag-specific CHANGELOG
+        id: create_changelog
+        run: |
+          set -e
+          CHANGELOG_PATH=$RUNNER_TEMP/CHANGELOG.md
+          awk '/^##[[:space:]].*/ { if (count == 1) exit; count++; print } count == 1 && !/^##[[:space:]].*/ { print }' CHANGELOG.md | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' > $CHANGELOG_PATH
+          echo -en "\n[https://pub.dev/packages/$NAME/versions/$VERSION](https://pub.dev/packages/$NAME/versions/$VERSION)" >> $CHANGELOG_PATH
+          echo "CHANGELOG_PATH=$CHANGELOG_PATH" >> $GITHUB_ENV
+      - id: dependencies
+        run: dart pub get
+      - id: check_if_dry_run
+        run: |
+          set -e
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$BRANCH_NAME" == "release/"* ]]; then
+            echo "DRY_RUN=true" >> $GITHUB_ENV
+          else
+            echo "DRY_RUN=false" >> $GITHUB_ENV
+          fi
+      - id: publish_dry_run
+        if: ${{ github.event_name == 'pull_request' && startsWith(github.ref_name, 'release/') }}
+        run: |
+          set -e
+          dart pub publish --dry-run
+      - id: publish
+        if: ${{ github.event_name == 'push' && startsWith(github.ref_name, format('refs/tags/{0}', matrix.package)) }}
+        run: |
+          set -e
+          dart pub publish --force
+      - id: create_release
+        if: ${{ steps.publish.conclusion == 'success' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ env.VERSION }}
+          tag_name: v${{ env.VERSION }}
+          body_path: ${{ env.CHANGELOG_PATH }}
+      - id: cleanup
+        if: ${{ always() }}
+        run: |
+          rm -rf $CHANGELOG_PATH

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       id-token: write
     runs-on: ubuntu-latest
-    environment: pub.dev # @petercinibulk needs to be added in the repo environment settings + configured on https://pub.dev
+    environment: pub.dev
     strategy:
       matrix:
         package: [ envied, envied_generator ]

--- a/.github/workflows/publish_dry_run.yml
+++ b/.github/workflows/publish_dry_run.yml
@@ -1,0 +1,56 @@
+name: Publish [DRY RUN]
+
+on:
+  pull_request:
+    branches:
+      - 'release/v**'
+      - 'release/envied/v**'
+      - 'release/envied_generator/v**'
+defaults:
+  run:
+    shell: bash
+env:
+  PUB_ENVIRONMENT: bot.github
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+    with:
+      upload_coverage: false
+  publish:
+    needs: test
+    name: "Publish [DRY RUN]"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [ envied, envied_generator ]
+      fail-fast: true
+      max-parallel: 1
+    if: ${{ startsWith(github.head_ref || github.ref_name, 'release/v') || startsWith(github.head_ref || github.ref_name, format('release/{0}/v', matrix.package)) }}
+    defaults:
+      run:
+        working-directory: packages/${{ matrix.package }}
+    steps:
+      - id: setup_dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v3
+      - id: read_version_from_pubspec
+        run: |
+          set -e
+          VERSION=$(yq -r '.version' pubspec.yaml)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - id: check_changelog
+        run: |
+          set -e
+          if ! grep -q "## $VERSION" CHANGELOG.md; then
+            echo "CHANGELOG.md does not contain a section for $VERSION"
+            exit 1
+          fi
+      - id: dependencies
+        run: dart pub get
+      - id: publish_dry_run
+        run: dart pub publish --dry-run

--- a/.github/workflows/publish_dry_run.yml
+++ b/.github/workflows/publish_dry_run.yml
@@ -50,6 +50,16 @@ jobs:
             echo "CHANGELOG.md does not contain a section for $VERSION"
             exit 1
           fi
+      - id: validate_pub_dev_topics
+        run: |
+          set -e
+          pattern="^[a-z][a-z0-9-]*[a-z0-9]$"
+          for topic in $(yq -r '.topics[]' pubspec.yaml); do
+            if [[ ! $topic =~ $pattern ]]; then
+              echo "Invalid topic: $topic"
+              exit 1
+            fi
+          done
       - id: dependencies
         run: dart pub get
       - id: publish_dry_run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Main
+name: Test
 
 on:
   push:


### PR DESCRIPTION
Addresses #51

I have made the `main.yml` workflow reusable and used it as a test job upon which the publish job depends.

1. a `pull_request` of a branch named `release/*` will trigger a dry run
2. a `push` will trigger a deployment if the tags match this pattern:
  - `'envied-v[0-9]+.[0-9]+.[0-9]+*'`
  - `'envied_generator-v[0-9]+.[0-9]+.[0-9]+*'`

I didn't use melos here as I saw no need and because melos uses `dart pub publish` [under the hood anyway](https://melos.invertase.dev/guides/automated-releases#publishing).

I have left a comment for you in the workflow where you will have to create an environment with the name `pub.dev` (or you can name it differently) just as it's outlined here in [this guide](https://dart.dev/tools/pub/automated-publishing#configuring-automated-publishing-from-github-actions-on-pubdev).