### PR TITLE
chore: fix publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
     name: "Publish"
     permissions:
       id-token: write
+      contents: write
     runs-on: ubuntu-latest
     environment: pub.dev
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish
 on:
   push:
     tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
       - 'envied-v[0-9]+.[0-9]+.[0-9]+*'
       - 'envied_generator-v[0-9]+.[0-9]+.[0-9]+*'
 defaults:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
-      - 'envied-v[0-9]+.[0-9]+.[0-9]+*'
-      - 'envied_generator-v[0-9]+.[0-9]+.[0-9]+*'
 defaults:
   run:
     shell: bash
@@ -32,33 +30,28 @@ jobs:
       fail-fast: true
       max-parallel: 1
     steps:
-      - id: should_publish
-        name: Check if should publish
-        run: |
-          set -e
-          if [[ $GITHUB_REF =~ ^refs/tags/${{ matrix.package }} ]]; then
-            echo "SHOULD_RUN=1" >> $GITHUB_ENV
-          else
-            echo "SHOULD_RUN=0" >> $GITHUB_ENV
-          fi
-      - id: setup_dart
-        name: Setup Dart SDK
-        if: ${{ env.SHOULD_RUN == 1 }}
-        uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
       - id: checkout
         name: Checkout repository
-        if: ${{ env.SHOULD_RUN == 1 }}
         uses: actions/checkout@v3
       - id: read_version_from_pubspec
         name: Read version from pubspec
-        if: ${{ env.SHOULD_RUN == 1 }}
         working-directory: packages/${{ matrix.package }}
         run: |
           set -e
           VERSION=$(yq -r '.version' pubspec.yaml)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Compare version with ref/tag
+        id: compare_version_with_tag
+        run: |
+          set -e
+          TAG=${GITHUB_REF_NAME#v}
+          if [[ "$VERSION" != "$TAG" ]]; then
+            echo "Version in ${{ matrix.package }}/pubspec.yaml ($VERSION) does not match tag ($TAG)"
+            echo "Skipping publish for ${{ matrix.package }}"
+            echo "SHOULD_RUN=0" >> $GITHUB_ENV
+          else
+            echo "SHOULD_RUN=1" >> $GITHUB_ENV
+          fi
       - id: check_changelog
         name: Check CHANGELOG.md
         if: ${{ env.SHOULD_RUN == 1 }}
@@ -92,6 +85,12 @@ jobs:
           awk '/^##[[:space:]].*/ { if (count == 1) exit; count++; print } count == 1 && !/^##[[:space:]].*/ { print }' CHANGELOG.md | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' > $CHANGELOG_PATH
           echo -en "\n[https://pub.dev/packages/$NAME/versions/$VERSION](https://pub.dev/packages/$NAME/versions/$VERSION)" >> $CHANGELOG_PATH
           echo "CHANGELOG_PATH=$CHANGELOG_PATH" >> $GITHUB_ENV
+      - id: setup_dart
+        name: Setup Dart SDK
+        if: ${{ env.SHOULD_RUN == 1 }}
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
       - id: melos
         name: Activate melos
         if: ${{ env.SHOULD_RUN == 1 }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
           set -e
           CHANGELOG_PATH=$RUNNER_TEMP/CHANGELOG.md
           awk '/^##[[:space:]].*/ { if (count == 1) exit; count++; print } count == 1 && !/^##[[:space:]].*/ { print }' CHANGELOG.md | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' > $CHANGELOG_PATH
-          echo -en "\n[https://pub.dev/packages/$NAME/versions/$VERSION](https://pub.dev/packages/$NAME/versions/$VERSION)" >> $CHANGELOG_PATH
+          echo -en "\n[https://pub.dev/packages/${{ matrix.package }}/versions/$VERSION](https://pub.dev/packages/${{ matrix.package }}/versions/$VERSION)" >> $CHANGELOG_PATH
           echo "CHANGELOG_PATH=$CHANGELOG_PATH" >> $GITHUB_ENV
       - id: setup_dart
         name: Setup Dart SDK


### PR DESCRIPTION
Added

```yaml
on:
  push:
    tags:
      - 'v[0-9]+.[0-9]+.[0-9]+*'
```

so that a tag like that can also trigger a release.

Additionally I added the check

```yaml
- name: Compare version with ref/tag
  id: compare_version_with_tag
  run: |
    set -e
    TAG=${GITHUB_REF_NAME#v}
    if [[ "$VERSION" != "$TAG" ]]; then
      echo "Version in ${{ matrix.package }}/pubspec.yaml ($VERSION) does not match tag ($TAG)"
      echo "Skipping publish for ${{ matrix.package }}"
      echo "SHOULD_RUN=0" >> $GITHUB_ENV
    else
      echo "SHOULD_RUN=1" >> $GITHUB_ENV
    fi
```