### PR TITLE
feat: Obfuscated `double`s and `num`s

### DIFF
--- a/packages/envied/README.md
+++ b/packages/envied/README.md
@@ -140,13 +140,18 @@ print(Env.key1); // "VALUE1"
 print(Env.KEY2); // "VALUE2"
 ```
 
-### Obfuscation
+### Obfuscation/Encryption
 
-Add the ofuscate flag to EnviedField
+Add the `obfuscate` flag to EnviedField
 
 ```dart
 @EnviedField(obfuscate: true)
 ```
+
+**Please keep in mind that this only increases the amount of effort to retrieve the
+obfuscated/encrypted values. If someone tries hard enough, he will eventually find the values.
+For more information, see https://github.com/frencojobs/envify/pull/28 and
+https://github.com/petercinibulk/envied/pull/4!**
 
 ### **Optional Environment Variables**
 

--- a/packages/envied/README.md
+++ b/packages/envied/README.md
@@ -130,10 +130,7 @@ abstract class Env {
 Then run the generator:
 
 ```sh
-# dart
 dart run build_runner build
-# flutter
-flutter pub run build_runner build
 ```
 
 You can then use the Env class to access your environment variables:

--- a/packages/envied_generator/lib/src/generate_field_encrypted.dart
+++ b/packages/envied_generator/lib/src/generate_field_encrypted.dart
@@ -218,8 +218,7 @@ Iterable<Field> generateFieldsEncrypted(
             ]),
       ],
     );
-    if (field.type.isDartCoreDouble ||
-        field.type.isDartCoreNum) {
+    if (field.type.isDartCoreDouble || field.type.isDartCoreNum) {
       final num? parsed = num.tryParse(value);
 
       if (parsed == null) {

--- a/packages/envied_generator/lib/src/generate_field_encrypted.dart
+++ b/packages/envied_generator/lib/src/generate_field_encrypted.dart
@@ -35,14 +35,16 @@ Iterable<Field> generateFieldsEncrypted(
 
     // Early return if null, so need to check for allowed types
     if (!field.type.isDartCoreInt &&
+        !field.type.isDartCoreDouble &&
+        !field.type.isDartCoreNum &&
         !field.type.isDartCoreBool &&
         !field.type.isDartCoreUri &&
         !field.type.isDartCoreDateTime &&
         !field.type.isDartCoreString &&
         field.type is! DynamicType) {
       throw InvalidGenerationSourceError(
-        'Obfuscated envied can only handle types such as `int`, `bool`, '
-        '`Uri`, `DateTime` and `String`. '
+        'Obfuscated envied can only handle types such as `int`, `double`, '
+        '`num`, `bool`, `Uri`, `DateTime` and `String`. '
         'Type `$type` is not one of them.',
         element: field,
       );
@@ -146,7 +148,9 @@ Iterable<Field> generateFieldsEncrypted(
     ];
   }
 
-  if (field.type.isDartCoreUri ||
+  if (field.type.isDartCoreDouble ||
+      field.type.isDartCoreNum ||
+      field.type.isDartCoreUri ||
       field.type.isDartCoreDateTime ||
       field.type.isDartCoreString ||
       field.type is DynamicType) {
@@ -214,7 +218,20 @@ Iterable<Field> generateFieldsEncrypted(
             ]),
       ],
     );
-    if (field.type.isDartCoreUri) {
+    if (field.type.isDartCoreDouble ||
+        field.type.isDartCoreNum) {
+      final num? parsed = num.tryParse(value);
+
+      if (parsed == null) {
+        throw InvalidGenerationSourceError(
+          'Type `$type` does not align with value `$value`.',
+          element: field,
+        );
+      }
+
+      symbol = field.type.isDartCoreDouble ? 'double' : 'num';
+      result = refer(symbol).type.newInstanceNamed('parse', [stringExpression]);
+    } else if (field.type.isDartCoreUri) {
       symbol = 'Uri';
       result = refer('Uri').type.newInstanceNamed('parse', [stringExpression]);
     } else if (field.type.isDartCoreDateTime) {
@@ -261,8 +278,8 @@ Iterable<Field> generateFieldsEncrypted(
   }
 
   throw InvalidGenerationSourceError(
-    'Obfuscated envied can only handle types such as `int`, `bool`, '
-    '`Uri`, `DateTime` and `String`. '
+    'Obfuscated envied can only handle types such as `int`, `double`, '
+    '`num`, `bool`, `Uri`, `DateTime` and `String`. '
     'Type `$type` is not one of them.',
     element: field,
   );

--- a/packages/envied_generator/test/.env.example
+++ b/packages/envied_generator/test/.env.example
@@ -2,6 +2,7 @@ test_string=test_string
 testString=testString
 testInt=123
 testDouble=1.23
+testNum=1.23
 testBool=true
 testDynamic=123abc
 testUrl=https://foo.bar/baz

--- a/packages/envied_generator/test/src/generator_tests.dart
+++ b/packages/envied_generator/test/src/generator_tests.dart
@@ -502,7 +502,7 @@ abstract class Env21 {
 }
 
 @ShouldThrow(
-  'Obfuscated envied can only handle types such as `int`, `bool`, `Uri`, `DateTime` and `String`. Type `Symbol` is not one of them.',
+  'Obfuscated envied can only handle types such as `int`, `double`, `num`, `bool`, `Uri`, `DateTime` and `String`. Type `Symbol` is not one of them.',
 )
 @Envied(path: 'test/.env.example')
 abstract class Env22 {
@@ -800,4 +800,66 @@ abstract class Env31cInvalid {
 abstract class Env31dInvalid {
   @EnviedField(obfuscate: true)
   static final DateTime? invalidTestDate = null;
+}
+
+@ShouldGenerate('static const List<int> _enviedkeytestDouble', contains: true)
+@ShouldGenerate('static const List<int> _envieddatatestDouble', contains: true)
+@ShouldGenerate('''
+  static final double testDouble =
+      double.parse(String.fromCharCodes(List<int>.generate(
+    _envieddatatestDouble.length,
+    (int i) => i,
+    growable: false,
+  ).map((int i) => _envieddatatestDouble[i] ^ _enviedkeytestDouble[i])));
+''', contains: true)
+@Envied(path: 'test/.env.example')
+abstract class Env32a {
+  @EnviedField(obfuscate: true)
+  static const double testDouble = 1.23;
+}
+
+@ShouldGenerate('static const List<int> _enviedkeytestDouble', contains: true)
+@ShouldGenerate('static const List<int> _envieddatatestDouble', contains: true)
+@ShouldGenerate('''
+  static final double? testDouble =
+      double.parse(String.fromCharCodes(List<int>.generate(
+    _envieddatatestDouble.length,
+    (int i) => i,
+    growable: false,
+  ).map((int i) => _envieddatatestDouble[i] ^ _enviedkeytestDouble[i])));
+''', contains: true)
+@Envied(path: 'test/.env.example', allowOptionalFields: true)
+abstract class Env32b {
+  @EnviedField(obfuscate: true)
+  static const double? testDouble = 1.23;
+}
+
+@ShouldGenerate('static const List<int> _enviedkeytestNum', contains: true)
+@ShouldGenerate('static const List<int> _envieddatatestNum', contains: true)
+@ShouldGenerate('''
+  static final num testNum = num.parse(String.fromCharCodes(List<int>.generate(
+    _envieddatatestNum.length,
+    (int i) => i,
+    growable: false,
+  ).map((int i) => _envieddatatestNum[i] ^ _enviedkeytestNum[i])));
+''', contains: true)
+@Envied(path: 'test/.env.example')
+abstract class Env33a {
+  @EnviedField(obfuscate: true)
+  static const num testNum = 1.23;
+}
+
+@ShouldGenerate('static const List<int> _enviedkeytestNum', contains: true)
+@ShouldGenerate('static const List<int> _envieddatatestNum', contains: true)
+@ShouldGenerate('''
+  static final num? testNum = num.parse(String.fromCharCodes(List<int>.generate(
+    _envieddatatestNum.length,
+    (int i) => i,
+    growable: false,
+  ).map((int i) => _envieddatatestNum[i] ^ _enviedkeytestNum[i])));
+''', contains: true)
+@Envied(path: 'test/.env.example', allowOptionalFields: true)
+abstract class Env33b {
+  @EnviedField(obfuscate: true)
+  static const num? testNum = 1.23;
 }


### PR DESCRIPTION
Please merge #70 first. Then I will mark this draft as ready :)

I ultimately decided against the IEEE 754 approach since the user needs to specify the `double` as a string anyway.
This way, it was very easy to simultaneously add `double` and `num` support.

Fixes #71 
