### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,11 +82,6 @@ Packages with other changes:
 
  - **REFACTOR**: facelift both Envied and EnviedGenerator to Dart 3.0 (#46).
 
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
 ## 2023-05-11
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,60 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2023-11-14
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+### Packages with other changes:
+
+ - [`envied` - `v0.5.2`](#envied---v052)
+ - [`envied_generator` - `v0.5.2`](#enviedgenerator---v052)
+
+---
+
+#### `envied` - `v0.5.2`
+
+ - **FEAT**: add ability to convert field name from camelCase to CONSTANT_CASE (#42)
+
+#### `envied_generator` - `v0.5.2`
+
+ - **FEAT**: add ability to convert field name from camelCase to CONSTANT_CASE (#42)
+ - **FEAT**: generated files are now ignored in the coverage report (#62)
+ - **FEAT**: add support for Uri fields (#70)
+ - **FEAT**: add support for DateTime fields (#70)
+ - **FEAT**: add support for enum fields (#73)
+
+## 2023-11-04
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+### Packages with other changes:
+
+ - [`envied` - `v0.5.1`](#envied---v051)
+ - [`envied_generator` - `v0.5.`](#enviedgenerator---v051)
+
+---
+
+#### `envied` - `v0.5.1`
+
+ - **FEAT**: add null value support (#66)
+
+#### `envied_generator` - `v0.5.1`
+
+ - **FEAT**: add null value support (#66)
+
 ## 2023-09-22
 
 ### Changes
@@ -15,8 +69,8 @@ Packages with breaking changes:
 
 Packages with other changes:
 
- - [`envied` - `v0.5.0`](#envied---v0501)
- - [`envied_generator` - `v0.5.0`](#envied_generator---v0501)
+ - [`envied` - `v0.5.0`](#envied---v050)
+ - [`envied_generator` - `v0.5.0`](#enviedgenerator---v050)
 
 ---
 
@@ -46,7 +100,7 @@ Packages with breaking changes:
 Packages with other changes:
 
  - [`envied` - `v0.3.0+3`](#envied---v0303)
- - [`envied_generator` - `v0.3.0+3`](#envied_generator---v0303)
+ - [`envied_generator` - `v0.3.0+3`](#enviedgenerator---v0303)
 
 ---
 
@@ -72,7 +126,7 @@ Packages with breaking changes:
 Packages with other changes:
 
  - [`envied` - `v0.3.0+1`](#envied---v0301)
- - [`envied_generator` - `v0.3.0+1`](#envied_generator---v0301)
+ - [`envied_generator` - `v0.3.0+1`](#enviedgenerator---v0301)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Packages with breaking changes:
  - **FEAT**: generated files are now ignored in the coverage report (#62)
  - **FEAT**: add support for Uri fields (#70)
  - **FEAT**: add support for DateTime fields (#70)
+ - **FEAT**: add support for obfuscated double fields (#72)
+ - **FEAT**: add support for obfuscated num fields (#72)
  - **FEAT**: add support for enum fields (#73)
 
 ## 2023-11-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Packages with breaking changes:
 ### Packages with other changes:
 
  - [`envied` - `v0.5.1`](#envied---v051)
- - [`envied_generator` - `v0.5.`](#enviedgenerator---v051)
+ - [`envied_generator` - `v0.5.1`](#enviedgenerator---v051)
 
 ---
 

--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+ - **FEAT**: add ability to convert field name from camelCase to CONSTANT_CASE (#42)
+
 ## 0.5.1
 
  - **FEAT**: add null value support (#61)

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -4,7 +4,9 @@
  - **FEAT**: generated files are now ignored in the coverage report (#62)
  - **FEAT**: add support for Uri fields (#70)
  - **FEAT**: add support for DateTime fields (#70)
- - **FEAT**: add support for Enum fields (#73)
+ - **FEAT**: add support for obfuscated double fields (#72)
+ - **FEAT**: add support for obfuscated num fields (#72)
+ - **FEAT**: add support for enum fields (#73)
 
 ## 0.5.1
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.5.2
+
+ - **FEAT**: add ability to convert field name from camelCase to CONSTANT_CASE (#42)
+ - **FEAT**: generated files are now ignored in the coverage report (#62)
+ - **FEAT**: add support for Uri fields (#70)
+ - **FEAT**: add support for DateTime fields (#70)
+ - **FEAT**: add support for Enum fields (#73)
+
 ## 0.5.1
 
  - **FEAT**: add null value support (#61)

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 


### PR DESCRIPTION
## 2023-11-14

### Changes

---

Packages with breaking changes:

 - There are no breaking changes in this release.

### Packages with other changes:

 - [`envied` - `v0.5.2`](#envied---v052)
 - [`envied_generator` - `v0.5.2`](#enviedgenerator---v052)

---

#### `envied` - `v0.5.2`

 - **FEAT**: add ability to convert field name from camelCase to CONSTANT_CASE (#42)

#### `envied_generator` - `v0.5.2`

 - **FEAT**: add ability to convert field name from camelCase to CONSTANT_CASE (#42)
 - **FEAT**: generated files are now ignored in the coverage report (#62)
 - **FEAT**: add support for Uri fields (#70)
 - **FEAT**: add support for DateTime fields (#70)
 - **FEAT**: add support for obfuscated double fields (#72)
 - **FEAT**: add support for obfuscated num fields (#72)
 - **FEAT**: add support for enum fields (#73)
