### PR TITLE
chore: update actions/checkout to v4 (was v3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: read_version_from_pubspec
         name: Read version from pubspec
         working-directory: packages/${{ matrix.package }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: setup_dart
         name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1
@@ -88,7 +88,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: setup_dart
         name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
Update [actions/checkout](https://github.com/actions/checkout) to v4 (was v3)