### PR TITLE
fix: prevent Github Release from overwriting a release with the same tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,8 +83,7 @@ jobs:
         run: |
           set -e
           CHANGELOG_PATH=$RUNNER_TEMP/CHANGELOG.md
-          echo "# ${{ matrix.package }}\n" > $CHANGELOG_PATH
-          awk '/^##[[:space:]].*/ { if (count == 1) exit; count++; print } count == 1 && !/^##[[:space:]].*/ { print }' CHANGELOG.md | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' >> $CHANGELOG_PATH
+          awk '/^##[[:space:]].*/ { if (count == 1) exit; count++; print } count == 1 && !/^##[[:space:]].*/ { print }' CHANGELOG.md | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' > $CHANGELOG_PATH
           echo -en "\n[https://pub.dev/packages/${{ matrix.package }}/versions/$VERSION](https://pub.dev/packages/${{ matrix.package }}/versions/$VERSION)" >> $CHANGELOG_PATH
           echo "CHANGELOG_PATH=$CHANGELOG_PATH" >> $GITHUB_ENV
       - id: setup_dart

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,8 @@ jobs:
         run: |
           set -e
           CHANGELOG_PATH=$RUNNER_TEMP/CHANGELOG.md
-          awk '/^##[[:space:]].*/ { if (count == 1) exit; count++; print } count == 1 && !/^##[[:space:]].*/ { print }' CHANGELOG.md | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' > $CHANGELOG_PATH
+          echo "# ${{ matrix.package }}\n" > $CHANGELOG_PATH
+          awk '/^##[[:space:]].*/ { if (count == 1) exit; count++; print } count == 1 && !/^##[[:space:]].*/ { print }' CHANGELOG.md | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' >> $CHANGELOG_PATH
           echo -en "\n[https://pub.dev/packages/${{ matrix.package }}/versions/$VERSION](https://pub.dev/packages/${{ matrix.package }}/versions/$VERSION)" >> $CHANGELOG_PATH
           echo "CHANGELOG_PATH=$CHANGELOG_PATH" >> $GITHUB_ENV
       - id: setup_dart
@@ -115,6 +116,7 @@ jobs:
         if: ${{ env.SHOULD_RUN == 1 }}
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ format('{0}-v{1}', matrix.package, env.VERSION) }}
           name: ${{ format('{0}-v{1}', matrix.package, env.VERSION) }}
           body_path: ${{ env.CHANGELOG_PATH }}
       - id: cleanup


### PR DESCRIPTION
I noticed that [softprops/action-gh-release](https://github.com/softprops/action-gh-release) is [overwriting](https://github.com/petercinibulk/envied/actions/runs/6916291046/job/18816230176#step:13:16) a [previous](https://github.com/petercinibulk/envied/actions/runs/6916291046/job/18816230091#step:13:15) Girthub Release with the same tag because I forgot to explicitly add a `tag_name`. 🙈