### PR TITLE
chore: release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-01-03
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+### Packages with other changes:
+
+ - [`envied` - `v0.5.3`](#envied---v053)
+ - [`envied_generator` - `v0.5.3`](#enviedgenerator---v053)
+
+---
+
+#### `envied` - `v0.5.3`
+
+ - **FEAT**: optional path build.yaml option (#83)
+ - **CHORE**: update readme regarding #6 (#79)
+
+#### `envied_generator` - `v0.5.3`
+
+ - **FEAT**: optional path build.yaml option (#83)
+ - **REFACTOR**: replace `Code` blocks with dedicated `Expression.operatorBitwiseXor` (#81)
+ - **REFACTOR**: use `TypeReference` instead of raw `refer` for `List`s (#81)
+
 ## 2023-11-14
 
 ### Changes

--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.3
+
+ - **FEAT**: optional path build.yaml option (#83)
+ - **CHORE**: update readme regarding #6 (#79)
+
 ## 0.5.2
 
  - **FEAT**: add ability to convert field name from camelCase to CONSTANT_CASE (#42)

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 0.5.2
+version: 0.5.3
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.3
+
+ - **FEAT**: optional path build.yaml option (#83)
+ - **REFACTOR**: replace `Code` blocks with dedicated `Expression.operatorBitwiseXor` (#81)
+ - **REFACTOR**: use `TypeReference` instead of raw `refer` for `List`s (#81)
+
 ## 0.5.2
 
  - **FEAT**: add ability to convert field name from camelCase to CONSTANT_CASE (#42)

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 0.5.2
+version: 0.5.3
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 


### PR DESCRIPTION
## 2024-01-03

### Changes

---

Packages with breaking changes:

 - There are no breaking changes in this release.

### Packages with other changes:

 - [`envied` - `v0.5.3`](#envied---v053)
 - [`envied_generator` - `v0.5.3`](#enviedgenerator---v053)

---

#### `envied` - `v0.5.3`

 - **FEAT**: optional path build.yaml option (#83)
 - **CHORE**: update readme regarding #6 (#79)

#### `envied_generator` - `v0.5.3`

 - **FEAT**: optional path build.yaml option (#83)
 - **REFACTOR**: replace `Code` blocks with dedicated `Expression.operatorBitwiseXor` (#81)
 - **REFACTOR**: use `TypeReference` instead of raw `refer` for `List`s (#81)