### PR TITLE
feat: add @envied annotation with default options

### DIFF
--- a/examples/envied_example/pubspec.lock
+++ b/examples/envied_example/pubspec.lock
@@ -167,14 +167,14 @@ packages:
       path: "../../packages/envied"
       relative: true
     source: path
-    version: "0.5.2"
+    version: "0.5.3"
   envied_generator:
     dependency: "direct dev"
     description:
       path: "../../packages/envied_generator"
       relative: true
     source: path
-    version: "0.5.2"
+    version: "0.5.3"
   file:
     dependency: transitive
     description:

--- a/packages/envied/README.md
+++ b/packages/envied/README.md
@@ -54,7 +54,7 @@ import 'package:envied/envied.dart';
 
 part 'env.g.dart';
 
-@Envied()
+@envied
 abstract class Env {
     @EnviedField(varName: 'KEY')
     static const key = _Env.key;

--- a/packages/envied/lib/src/envied_base.dart
+++ b/packages/envied/lib/src/envied_base.dart
@@ -1,3 +1,6 @@
+/// Annotation with default options
+const envied = Envied();
+
 /// Annotation used to specify the class to contain environment variables that will be generated from a `.env` file.
 final class Envied {
   /// The file path of the `.env` file, relative to the project root, which


### PR DESCRIPTION
I've added simplified version on annotation with default options.

Instead of writing this:

`@Envied()`

Now we can write this as well:

`@envied`

Same convention is used in [@freezed](https://github.com/rrousselGit/freezed/blob/e61af260968b5762792a0a2e0016bdb3ccf0df23/packages/freezed_annotation/lib/freezed_annotation.dart#L497) or [@riverpod](https://github.com/rrousselGit/riverpod/blob/5c853b424cacf4774c81ccec688c3345f97edae7/packages/riverpod_annotation/lib/src/riverpod_annotation.dart#L106)