### PR TITLE
feat: add support for raw strings

### DIFF
--- a/packages/envied/lib/src/envied_base.dart
+++ b/packages/envied/lib/src/envied_base.dart
@@ -72,6 +72,15 @@ final class Envied {
   /// ```
   final bool useConstantCase;
 
+  /// Whether to use the raw string format for all string values.
+  ///
+  /// **NOTE**: The string is always formatted `'<value>'`.
+  ///
+  /// If [rawStrings] is `true`, all Strings will be raw formatted `r'<value>'`
+  /// and the value may not contain a single quote.
+  /// Escapes single quotes and newlines in the value.
+  final bool rawStrings;
+
   const Envied({
     String? path,
     bool? requireEnvFile,
@@ -79,6 +88,7 @@ final class Envied {
     this.obfuscate = false,
     this.allowOptionalFields = false,
     this.useConstantCase = false,
+    this.rawStrings = false,
   })  : path = path ?? '.env',
         requireEnvFile = requireEnvFile ?? false;
 }
@@ -128,11 +138,23 @@ final class EnviedField {
   /// ```
   final bool? useConstantCase;
 
+  /// Whether to use the raw string format for the value.
+  ///
+  /// Can only be used with a [String] type.
+  ///
+  /// **NOTE**: The string is always formatted `'<value>'`.
+  ///
+  /// If [rawString] is `true`, creates a raw String formatted `r'<value>'`
+  /// and the value may not contain a single quote.
+  /// Escapes single quotes and newlines in the value.
+  final bool? rawString;
+
   const EnviedField({
     this.varName,
     this.obfuscate,
     this.defaultValue,
     this.optional,
     this.useConstantCase,
+    this.rawString,
   });
 }

--- a/packages/envied_generator/lib/src/generate_field.dart
+++ b/packages/envied_generator/lib/src/generate_field.dart
@@ -15,6 +15,7 @@ Iterable<Field> generateFields(
   FieldElement field,
   String? value, {
   bool allowOptional = false,
+  bool rawString = false,
 }) {
   final String type = field.type.getDisplayString(withNullability: false);
 
@@ -127,7 +128,10 @@ Iterable<Field> generateFields(
           literalString(value),
         ],
       );
-    } else if (field.type.isDartCoreString || field.type is DynamicType) {
+    } else if (field.type.isDartCoreString) {
+      modifier = FieldModifier.constant;
+      result = literalString(value, raw: rawString);
+    } else if (field.type is DynamicType) {
       modifier = FieldModifier.constant;
       result = literalString(value);
     } else {

--- a/packages/envied_generator/lib/src/generate_field_encrypted.dart
+++ b/packages/envied_generator/lib/src/generate_field_encrypted.dart
@@ -18,6 +18,7 @@ Iterable<Field> generateFieldsEncrypted(
   FieldElement field,
   String? value, {
   bool allowOptional = false,
+  bool rawString = false,
 }) {
   final Random rand = Random.secure();
   final String type = field.type.getDisplayString(withNullability: false);

--- a/packages/envied_generator/lib/src/generator.dart
+++ b/packages/envied_generator/lib/src/generator.dart
@@ -51,6 +51,7 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
           annotation.read('allowOptionalFields').literalValue as bool? ?? false,
       useConstantCase:
           annotation.read('useConstantCase').literalValue as bool? ?? false,
+      rawStrings: annotation.read('rawStrings').literalValue as bool? ?? false,
     );
 
     final Map<String, String> envs =
@@ -132,6 +133,9 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
     final bool optional = reader.read('optional').literalValue as bool? ??
         config.allowOptionalFields;
 
+    final bool rawString =
+        reader.read('rawString').literalValue as bool? ?? config.rawStrings;
+
     // Throw if value is null but the field is not nullable
     bool isNullable = field.type is DynamicType ||
         field.type.nullabilitySuffix == NullabilitySuffix.question;
@@ -144,6 +148,7 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
 
     return reader.read('obfuscate').literalValue as bool? ?? config.obfuscate
         ? generateFieldsEncrypted(field, varValue, allowOptional: optional)
-        : generateFields(field, varValue, allowOptional: optional);
+        : generateFields(field, varValue,
+            allowOptional: optional, rawString: rawString);
   }
 }

--- a/packages/envied_generator/test/.env.example
+++ b/packages/envied_generator/test/.env.example
@@ -1,6 +1,8 @@
 test_string=test_string
 testString=testString
 TEST_STRING=TEST_STRING
+testUnescapedString=foo$
+test_unescaped_string=bar$
 testInt=123
 TEST_INT=123
 testDouble=1.23

--- a/packages/envied_generator/test/.env.example_with_path_override
+++ b/packages/envied_generator/test/.env.example_with_path_override
@@ -1,2 +1,3 @@
 foo=bar
 baz=qux
+bad=unescaped$

--- a/packages/envied_generator/test/src/generator_tests.dart
+++ b/packages/envied_generator/test/src/generator_tests.dart
@@ -11,7 +11,7 @@ import 'example_enum.dart';
 @Envied()
 const foo = 'bar';
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env0 {}
@@ -95,7 +95,7 @@ abstract class Env7 {
   static const bool? testString = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env8 {
@@ -124,7 +124,7 @@ abstract class Env8 {
   static const testDynamic = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env8b {
@@ -153,7 +153,7 @@ abstract class Env8b {
   static const testDynamic = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env9 {
@@ -166,7 +166,7 @@ abstract class Env9 {
   static const String? testString = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env9b {
@@ -179,7 +179,7 @@ abstract class Env9b {
   static const String? testString = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env10 {
@@ -192,7 +192,7 @@ abstract class Env10 {
   static const String? systemVar = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env10b {
@@ -205,7 +205,7 @@ abstract class Env10b {
   static const String? systemVar = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Foo {
@@ -218,7 +218,7 @@ abstract class Env11 {
   static const String? testString = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Foo {
@@ -233,7 +233,7 @@ abstract class Env11b {
 
 @ShouldGenerate('static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestString', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final String testString = String.fromCharCodes(List<int>.generate(
     _envieddatatestString.length,
     (int i) => i,
@@ -248,7 +248,7 @@ abstract class Env12 {
 
 @ShouldGenerate('static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestString', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final String? testString = String.fromCharCodes(List<int>.generate(
     _envieddatatestString.length,
     (int i) => i,
@@ -263,7 +263,7 @@ abstract class Env12b {
 
 @ShouldGenerate('static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestString', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final String testString = String.fromCharCodes(List<int>.generate(
     _envieddatatestString.length,
     (int i) => i,
@@ -278,7 +278,7 @@ abstract class Env13 {
 
 @ShouldGenerate('static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestString', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final String? testString = String.fromCharCodes(List<int>.generate(
     _envieddatatestString.length,
     (int i) => i,
@@ -298,7 +298,7 @@ abstract class Env14 {
   static const String? testDefaultParam = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env14b {
@@ -311,7 +311,7 @@ abstract class Env14b {
   static const String? testDefaultParam = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env15 {
@@ -344,7 +344,7 @@ abstract class Env15 {
   static const dynamic testDynamic = '123abc';
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env15b {
@@ -373,7 +373,7 @@ abstract class Env15b {
   static const bool testBool = true;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env16 {
@@ -386,7 +386,7 @@ abstract class Env16 {
   static const String? testDefaultParam = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env16b {
@@ -401,7 +401,7 @@ abstract class Env16b {
 
 @ShouldGenerate('static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestString', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final String testString = String.fromCharCodes(List<int>.generate(
     _envieddatatestString.length,
     (int i) => i,
@@ -416,7 +416,7 @@ abstract class Env17 {
 
 @ShouldGenerate('static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestString', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final String? testString = String.fromCharCodes(List<int>.generate(
     _envieddatatestString.length,
     (int i) => i,
@@ -431,7 +431,7 @@ abstract class Env17b {
 
 @ShouldGenerate('static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestString', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final String testString = String.fromCharCodes(List<int>.generate(
     _envieddatatestString.length,
     (int i) => i,
@@ -446,7 +446,7 @@ abstract class Env18 {
 
 @ShouldGenerate('static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestString', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final String? testString = String.fromCharCodes(List<int>.generate(
     _envieddatatestString.length,
     (int i) => i,
@@ -461,7 +461,7 @@ abstract class Env18b {
 
 @ShouldGenerate('static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestString', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final String? testString = String.fromCharCodes(List<int>.generate(
     _envieddatatestString.length,
     (int i) => i,
@@ -520,7 +520,7 @@ abstract class Env20b {
 
 @ShouldGenerate('static const List<int> _enviedkeytestDynamic', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestDynamic', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final testDynamic = String.fromCharCodes(List<int>.generate(
     _envieddatatestDynamic.length,
     (int i) => i,
@@ -563,7 +563,7 @@ abstract class Env25 {
   static const dynamic foo = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final foo = null;
 ''', contains: true)
 @Envied(path: 'test/.env.example', allowOptionalFields: true)
@@ -572,7 +572,7 @@ abstract class Env25b {
   static const dynamic foo = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env26 {
@@ -585,7 +585,7 @@ abstract class Env26 {
   static const String? foo = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env27 {
@@ -598,7 +598,7 @@ abstract class Env27 {
   static const int? foo = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env28 {
@@ -611,7 +611,7 @@ abstract class Env28 {
   static const bool? foo = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env29 {
@@ -631,7 +631,7 @@ abstract class Env29invalid {
   static final Uri? invalidTestUrl = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env29b {
@@ -653,7 +653,7 @@ abstract class Env29bInvalid {
 
 @ShouldGenerate('static const List<int> _enviedkeytestUrl', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestUrl', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final Uri testUrl = Uri.parse(String.fromCharCodes(List<int>.generate(
     _envieddatatestUrl.length,
     (int i) => i,
@@ -675,7 +675,7 @@ abstract class Env29cInvalid {
 
 @ShouldGenerate('static const List<int> _enviedkeytestUrl', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestUrl', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final Uri? testUrl = Uri.parse(String.fromCharCodes(List<int>.generate(
     _envieddatatestUrl.length,
     (int i) => i,
@@ -695,7 +695,7 @@ abstract class Env29dInvalid {
   static final Uri? invalidTestUrl = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env29empty {
@@ -708,7 +708,7 @@ abstract class Env29empty {
   static final Uri? emptyTestUrl = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env30 {
@@ -722,7 +722,7 @@ abstract class Env30 {
   static final DateTime? testDateTime = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env30b {
@@ -739,7 +739,7 @@ abstract class Env30b {
 @ShouldGenerate('static const List<int> _enviedkeytestDateTime', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestDateTime',
     contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final DateTime testDateTime =
       DateTime.parse(String.fromCharCodes(List<int>.generate(
     _envieddatatestDateTime.length,
@@ -756,7 +756,7 @@ abstract class Env30c {
 @ShouldGenerate('static const List<int> _enviedkeytestDateTime', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestDateTime',
     contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final DateTime? testDateTime =
       DateTime.parse(String.fromCharCodes(List<int>.generate(
     _envieddatatestDateTime.length,
@@ -806,7 +806,7 @@ abstract class Env30dInvalid {
   static final DateTime? invalidTestDateTime = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env31 {
@@ -819,7 +819,7 @@ abstract class Env31 {
   static final DateTime? testDate = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env31b {
@@ -834,7 +834,7 @@ abstract class Env31b {
 
 @ShouldGenerate('static const List<int> _enviedkeytestDate', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestDate', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final DateTime testDate =
       DateTime.parse(String.fromCharCodes(List<int>.generate(
     _envieddatatestDate.length,
@@ -850,7 +850,7 @@ abstract class Env31c {
 
 @ShouldGenerate('static const List<int> _enviedkeytestDate', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestDate', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final DateTime? testDate =
       DateTime.parse(String.fromCharCodes(List<int>.generate(
     _envieddatatestDate.length,
@@ -894,7 +894,7 @@ abstract class Env31dInvalid {
 
 @ShouldGenerate('static const List<int> _enviedkeytestDouble', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestDouble', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final double testDouble =
       double.parse(String.fromCharCodes(List<int>.generate(
     _envieddatatestDouble.length,
@@ -910,7 +910,7 @@ abstract class Env32a {
 
 @ShouldGenerate('static const List<int> _enviedkeytestDouble', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestDouble', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final double? testDouble =
       double.parse(String.fromCharCodes(List<int>.generate(
     _envieddatatestDouble.length,
@@ -926,7 +926,7 @@ abstract class Env32b {
 
 @ShouldGenerate('static const List<int> _enviedkeytestNum', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestNum', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final num testNum = num.parse(String.fromCharCodes(List<int>.generate(
     _envieddatatestNum.length,
     (int i) => i,
@@ -941,7 +941,7 @@ abstract class Env33a {
 
 @ShouldGenerate('static const List<int> _enviedkeytestNum', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestNum', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final num? testNum = num.parse(String.fromCharCodes(List<int>.generate(
     _envieddatatestNum.length,
     (int i) => i,
@@ -954,7 +954,7 @@ abstract class Env33b {
   static const num? testNum = 1.23;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env34 {
@@ -991,7 +991,7 @@ abstract class Env34 {
   static const String testDynamic = '123_ABC';
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env35 {
@@ -1004,7 +1004,7 @@ abstract class Env35 {
   static final ExampleEnum? testEnum = null;
 }
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _Env35b {
@@ -1019,7 +1019,7 @@ abstract class Env35b {
 
 @ShouldGenerate('static const List<int> _enviedkeytestEnum', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestEnum', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final ExampleEnum testEnum =
       ExampleEnum.values.byName(String.fromCharCodes(List<int>.generate(
     _envieddatatestEnum.length,
@@ -1035,7 +1035,7 @@ abstract class Env35c {
 
 @ShouldGenerate('static const List<int> _enviedkeytestEnum', contains: true)
 @ShouldGenerate('static const List<int> _envieddatatestEnum', contains: true)
-@ShouldGenerate('''
+@ShouldGenerate(r'''
   static final ExampleEnum? testEnum =
       ExampleEnum.values.byName(String.fromCharCodes(List<int>.generate(
     _envieddatatestEnum.length,

--- a/packages/envied_generator/test/src/generator_tests.dart
+++ b/packages/envied_generator/test/src/generator_tests.dart
@@ -101,6 +101,8 @@ abstract class Env7 {
 final class _Env8 {
   static const String testString = 'testString';
 
+  static const String testUnescapedString = r'foo$';
+
   static const int testInt = 123;
 
   static const double testDouble = 1.23;
@@ -114,6 +116,8 @@ final class _Env8 {
 abstract class Env8 {
   @EnviedField()
   static const String? testString = null;
+  @EnviedField(rawString: true)
+  static const String? testUnescapedString = null;
   @EnviedField()
   static const int? testInt = null;
   @EnviedField()
@@ -130,6 +134,8 @@ abstract class Env8 {
 final class _Env8b {
   static const String? testString = 'testString';
 
+  static const String? testUnescapedString = r'foo$';
+
   static const int? testInt = 123;
 
   static const double? testDouble = 1.23;
@@ -143,6 +149,8 @@ final class _Env8b {
 abstract class Env8b {
   @EnviedField()
   static const String? testString = null;
+  @EnviedField(rawString: true)
+  static const String? testUnescapedString = null;
   @EnviedField()
   static const int? testInt = null;
   @EnviedField()
@@ -177,6 +185,19 @@ final class _Env9b {
 abstract class Env9b {
   @EnviedField(varName: 'test_string')
   static const String? testString = null;
+}
+
+@ShouldGenerate(r'''
+// coverage:ignore-file
+// ignore_for_file: type=lint
+final class _Env9c {
+  static const String testUnescapedString = r'bar$';
+}
+''')
+@Envied(path: 'test/.env.example', rawStrings: true)
+abstract class Env9c {
+  @EnviedField(varName: 'test_unescaped_string')
+  static const String? testUnescapedString = null;
 }
 
 @ShouldGenerate(r'''
@@ -361,6 +382,35 @@ final class _Env15b {
 ''')
 @Envied(path: 'test/.env.example', allowOptionalFields: true)
 abstract class Env15b {
+  @EnviedField(defaultValue: 'test_')
+  static const String? testDefaultParam = null;
+  @EnviedField()
+  static const String testString = 'testString';
+  @EnviedField()
+  static const int testInt = 123;
+  @EnviedField()
+  static const double testDouble = 1.23;
+  @EnviedField()
+  static const bool testBool = true;
+}
+
+@ShouldGenerate(r'''
+// coverage:ignore-file
+// ignore_for_file: type=lint
+final class _Env15c {
+  static const String testDefaultParam = r'test_';
+
+  static const String testString = r'testString';
+
+  static const int testInt = 123;
+
+  static const double testDouble = 1.23;
+
+  static const bool testBool = true;
+}
+''')
+@Envied(path: 'test/.env.example', rawStrings: true)
+abstract class Env15c {
   @EnviedField(defaultValue: 'test_')
   static const String? testDefaultParam = null;
   @EnviedField()

--- a/packages/envied_generator/test/src/generator_tests_with_path_override.dart
+++ b/packages/envied_generator/test/src/generator_tests_with_path_override.dart
@@ -3,7 +3,7 @@
 import 'package:envied/envied.dart';
 import 'package:source_gen_test/annotations.dart';
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _EnvWithPathOverride0 {}
@@ -11,7 +11,7 @@ final class _EnvWithPathOverride0 {}
 @Envied()
 abstract class EnvWithPathOverride0 {}
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _EnvWithPathOverride1 {}
@@ -19,7 +19,7 @@ final class _EnvWithPathOverride1 {}
 @Envied(requireEnvFile: true)
 abstract class EnvWithPathOverride1 {}
 
-@ShouldGenerate('''
+@ShouldGenerate(r'''
 // coverage:ignore-file
 // ignore_for_file: type=lint
 final class _EnvWithPathOverride2 {

--- a/packages/envied_generator/test/src/generator_tests_with_path_override.dart
+++ b/packages/envied_generator/test/src/generator_tests_with_path_override.dart
@@ -26,6 +26,8 @@ final class _EnvWithPathOverride2 {
   static const String foo = 'bar';
 
   static const String baz = 'qux';
+
+  static const String bad = r'unescaped$';
 }
 ''')
 @Envied()
@@ -34,4 +36,6 @@ abstract class EnvWithPathOverride2 {
   static const String? foo = null;
   @EnviedField()
   static const String? baz = null;
+  @EnviedField(rawString: true)
+  static const String? bad = null;
 }


### PR DESCRIPTION
Adds support for raw strings (i.e `r'some string$'`) to be passed from env files to generated dart files using either:
- the `@Envied(rawStrings: true)` annotation option which will generate all `Strings` as raw
- the `@EnviedField(rawString: true)` annotation option which will generate only the annotated `String` field as raw

Example:

```dart
@Envied(path: 'test/.env.example')
abstract class Env8 {
  @EnviedField()
  static const String? testString;
  @EnviedField(rawString: true)
  static const String? testUnescapedString;
}
```

---

Fixes #94 