### PR TITLE
chore: release v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-03-11
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+### Packages with other changes:
+
+ - [`envied` - `v0.5.4`](#envied---v054)
+ - [`envied_generator` - `v0.5.4`](#enviedgenerator---v054)
+
+---
+
+#### `envied` - `v0.5.4`
+
+ - **FEAT**: add support for raw strings and no interpolation (#95)
+ - **FEAT**: add @envied annotation with default options (#92)
+
+#### `envied_generator` - `v0.5.4`
+    
+ - **FEAT**: add support for raw strings and no interpolation (#95)
+
 ## 2024-01-03
 
 ### Changes

--- a/examples/envied_example/pubspec.lock
+++ b/examples/envied_example/pubspec.lock
@@ -175,6 +175,14 @@ packages:
       relative: true
     source: path
     version: "0.5.3"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   file:
     dependency: transitive
     description:

--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.4
+
+ - **FEAT**: add support for raw strings and no interpolation (#95)
+ - **FEAT**: add @envied annotation with default options (#92)
+
 ## 0.5.3
 
  - **FEAT**: optional path build.yaml option (#83)

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 0.5.3
+version: 0.5.4
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4
+
+ - **FEAT**: add support for raw strings and no interpolation (#95)
+
 ## 0.5.3
 
  - **FEAT**: optional path build.yaml option (#83)

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 0.5.3
+version: 0.5.4
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 


### PR DESCRIPTION
## 2024-03-11

### Changes

---

Packages with breaking changes:

 - There are no breaking changes in this release.

### Packages with other changes:

 - [`envied` - `v0.5.4`](#envied---v054)
 - [`envied_generator` - `v0.5.4`](#enviedgenerator---v054)

---

#### `envied` - `v0.5.4`

 - **FEAT**: add support for raw strings and no interpolation (#95)
 - **FEAT**: add @envied annotation with default options (#92)

#### `envied_generator` - `v0.5.4`

 - **FEAT**: add support for raw strings and no interpolation (#95)