### PR TITLE
:bug: fix #99 parsing lines with multiple equals signs

### DIFF
--- a/packages/envied_generator/lib/src/extensions.dart
+++ b/packages/envied_generator/lib/src/extensions.dart
@@ -25,3 +25,45 @@ extension EnumElementExtension on EnumElement {
   /// Return the names of the values defined by this enum.
   Iterable<String> get valueNames => values.map((FieldElement fe) => fe.name);
 }
+
+/// Taken from https://stackoverflow.com/questions/76038472/limit-string-split-to-a-maximum-number-of-elements#answer-76039017
+extension PartialSplit on String {
+  /// A version of [String.split] that limits splitting to return a [List]
+  /// of at most [count] items.
+  ///
+  /// [count] must be non-negative.  If [count] is 0, returns an empty
+  /// [List].
+  ///
+  /// If splitting this [String] would result in more than [count] items,
+  /// the final element will contain the unsplit remainder of this [String].
+  ///
+  /// If splitting this [String] would result in fewer than [count] items,
+  /// returns a [List] with only the split substrings.
+  List<String> partialSplit(Pattern pattern, int count) {
+    assert(count >= 0);
+
+    final List<String> result = [];
+
+    if (count == 0) {
+      return result;
+    }
+
+    int offset = 0;
+    final Iterable<Match> matches = pattern.allMatches(this);
+    for (var match in matches) {
+      if (result.length + 1 == count) {
+        break;
+      }
+
+      if (match.end - match.start == 0 && match.start == offset) {
+        continue;
+      }
+
+      result.add(substring(offset, match.start));
+      offset = match.end;
+    }
+    result.add(substring(offset));
+
+    return result;
+  }
+}

--- a/packages/envied_generator/lib/src/parser.dart
+++ b/packages/envied_generator/lib/src/parser.dart
@@ -1,4 +1,5 @@
 import 'package:envied_generator/src/env_val.dart';
+import 'package:envied_generator/src/extensions.dart';
 
 /// Creates key-value pairs from strings formatted as environment
 /// variable definitions.
@@ -39,7 +40,7 @@ final class Parser {
     if (!_isValid(stripped)) return {};
 
     /// Split the line into key and value.
-    final [String lhs, String rhs] = stripped.split('=');
+    final [String lhs, String rhs] = stripped.partialSplit('=', 2);
 
     /// Remove the 'export' keyword.
     final String key = swallow(lhs);

--- a/packages/envied_generator/test/.env.example
+++ b/packages/envied_generator/test/.env.example
@@ -24,3 +24,4 @@ testDate=2023-11-06
 invalidTestDate=2023
 testEnum=ipsum
 invalidTestEnum=foo
+API_KEY=6690043050=

--- a/packages/envied_generator/test/src/generator_tests.dart
+++ b/packages/envied_generator/test/src/generator_tests.dart
@@ -1149,3 +1149,18 @@ abstract class Env35dInvalid {
   @EnviedField(obfuscate: true)
   static final ExampleEnum? invalidTestEnum = null;
 }
+
+@ShouldGenerate(r'''
+// coverage:ignore-file
+// ignore_for_file: type=lint
+final class _Env36 {
+  static const String apiKey = '6690043050=';
+}
+''')
+@Envied(path: 'test/.env.example')
+abstract class Env36 {
+  @EnviedField(
+    varName: 'API_KEY',
+  )
+  static const String? apiKey = null;
+}


### PR DESCRIPTION
In v0.5.4 I introduced a simpler way of splitting a line by `=`

https://github.com/petercinibulk/envied/blob/e089d00a25630ac2e5a8d2f6f8029fe70d3f1e96/packages/envied_generator/lib/src/parser.dart#L42

However, this is inadequate when attempting to parse something like

```ini
API_KEY=6690043050=
```

This PR fixes this by implementing `String.partialSplit` inspired by this [StackOverflow answer](https://stackoverflow.com/questions/76038472/limit-string-split-to-a-maximum-number-of-elements#answer-76039017)

---

Fixes #99