### PR TITLE
chore: release v0.5.4+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-04-03
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+### Packages with other changes:
+
+ - [`envied` - `v0.5.4+1`](#envied---v0541)
+ - [`envied_generator` - `v0.5.4+1`](#enviedgenerator---v0541)
+
+---
+
+#### `envied` - `v0.5.4+1`
+
+ - **FIX**: fix parsing lines with multiple equal signs (#100)
+
+#### `envied_generator` - `v0.5.4+1`
+
+ - **FIX**: fix parsing lines with multiple equal signs (#100)
+
 ## 2024-03-11
 
 ### Changes

--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4+1
+
+ - **FIX**: fix parsing lines with multiple equal signs (#100)
+
 ## 0.5.4
 
  - **FEAT**: add support for raw strings and no interpolation (#95)

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 0.5.4
+version: 0.5.4+1
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4+1
+
+ - **FIX**: fix parsing lines with multiple equal signs (#100)
+
 ## 0.5.4
 
  - **FEAT**: add support for raw strings and no interpolation (#95)

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 0.5.4
+version: 0.5.4+1
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 


### PR DESCRIPTION
## 2024-04-03

### Changes

---

Packages with breaking changes:

 - There are no breaking changes in this release.

### Packages with other changes:

 - [`envied` - `v0.5.4+1`](#envied---v0541)
 - [`envied_generator` - `v0.5.4+1`](#enviedgenerator---v0541)

---

#### `envied` - `v0.5.4+1`

 - **FIX**: fix parsing lines with multiple equal signs (#100)

#### `envied_generator` - `v0.5.4+1`

 - **FIX**: fix parsing lines with multiple equal signs (#100)