### PR TITLE
docs: add info about obfuscation variables

### DIFF
--- a/packages/envied/README.md
+++ b/packages/envied/README.md
@@ -148,7 +148,10 @@ Add the `obfuscate` flag to EnviedField
 
 ```dart
 @EnviedField(obfuscate: true)
+static final String key = _Env.key;
 ```
+
+Note: In this case you should use `static final` instead of `static const`.
 
 **Please keep in mind that this only increases the amount of effort to retrieve the
 obfuscated/encrypted values. If someone tries hard enough, he will eventually find the values.


### PR DESCRIPTION
Added that you need static final variables instead of static const.