### PR TITLE
refactor: Switch to singleton pattern in app_env.dart

### DIFF
--- a/examples/envied_example/lib/app_env.dart
+++ b/examples/envied_example/lib/app_env.dart
@@ -9,7 +9,13 @@ abstract interface class AppEnv implements AppEnvFields {
   /// import 'package:flutter/foundation.dart';
   static const kDebugMode = true;
 
-  factory AppEnv() => _instance;
+  // Private constructor to prevent direct instantiation
+  AppEnv._();
+  
+  static AppEnv? _instance;
 
-  static final AppEnv _instance = kDebugMode ? DebugEnv() : ReleaseEnv();
+  factory AppEnv() {
+    _instance ??= kDebugMode ? DebugEnv() : ReleaseEnv();
+    return _instance!;
+  }
 }


### PR DESCRIPTION
Hey 👋

Little change that, I thought, is quite nice, especially regarding people who copy the example & use it straightaway.
 
The reasoning is that it is plain better, & more efficent to implement the Singleton pattern with the Dart Factories for the `AppEnv` than to create a new instance with each call to the constructor