### PR TITLE
feat: add support to custom random seed

### DIFF
--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - **FEAT**: add support for custom seed when using Random during the obfuscation.
+
 ## 0.5.4+1
 
  - **FIX**: fix parsing lines with multiple equal signs (#100)

--- a/packages/envied/lib/src/envied_base.dart
+++ b/packages/envied/lib/src/envied_base.dart
@@ -168,6 +168,7 @@ final class EnviedField {
 
   /// A seed can be provided if the obfuscation randomness needs to remain
   /// reproducible across builds.
+  /// **Note**: This will make the `Random` instance non-secure!
   final int? randomSeed;
 
   const EnviedField({

--- a/packages/envied/lib/src/envied_base.dart
+++ b/packages/envied/lib/src/envied_base.dart
@@ -86,6 +86,10 @@ final class Envied {
   /// Escapes single quotes and newlines in the value.
   final bool rawStrings;
 
+  /// A seed can be provided if the obfuscation randomness needs to remain
+  /// reproducible across builds.
+  final int? randomSeed;
+
   const Envied({
     String? path,
     bool? requireEnvFile,
@@ -95,6 +99,7 @@ final class Envied {
     this.useConstantCase = false,
     this.interpolate = true,
     this.rawStrings = false,
+    this.randomSeed,
   })  : path = path ?? '.env',
         requireEnvFile = requireEnvFile ?? false;
 }
@@ -160,6 +165,10 @@ final class EnviedField {
   /// Escapes single quotes and newlines in the value.
   final bool? rawString;
 
+  /// A seed can be provided if the obfuscation randomness needs to remain
+  /// reproducible across builds.
+  final int? randomSeed;
+
   const EnviedField({
     this.varName,
     this.obfuscate,
@@ -168,5 +177,6 @@ final class EnviedField {
     this.useConstantCase,
     this.interpolate,
     this.rawString,
+    this.randomSeed,
   });
 }

--- a/packages/envied/lib/src/envied_base.dart
+++ b/packages/envied/lib/src/envied_base.dart
@@ -88,6 +88,7 @@ final class Envied {
 
   /// A seed can be provided if the obfuscation randomness needs to remain
   /// reproducible across builds.
+  /// **Note**: This will make the `Random` instance non-secure!
   final int? randomSeed;
 
   const Envied({

--- a/packages/envied/test/envy_test.dart
+++ b/packages/envied/test/envy_test.dart
@@ -35,6 +35,11 @@ void main() {
       final envied = Envied(obfuscate: true);
       expect(envied.obfuscate, true);
     });
+
+    test('Specified randomSeed', () {
+      final envied = Envied(randomSeed: 123);
+      expect(envied.randomSeed, 123);
+    });
   });
 
   group('EnviedField Test Group', () {
@@ -64,6 +69,11 @@ void main() {
     test('Specified useConstantCase', () {
       final enviedField = EnviedField(useConstantCase: true);
       expect(enviedField.useConstantCase, isTrue);
+    });
+
+    test('Specified randomSeed', () {
+      final enviedField = EnviedField(randomSeed: 123);
+      expect(enviedField.randomSeed, 123);
     });
   });
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - **FEAT**: add support for custom seed when using Random during the obfuscation.
+
 ## 0.5.4+1
 
  - **FIX**: fix parsing lines with multiple equal signs (#100)

--- a/packages/envied_generator/lib/src/generate_field_encrypted.dart
+++ b/packages/envied_generator/lib/src/generate_field_encrypted.dart
@@ -18,8 +18,9 @@ Iterable<Field> generateFieldsEncrypted(
   FieldElement field,
   String? value, {
   bool allowOptional = false,
+  int? randomSeed,
 }) {
-  final Random rand = Random.secure();
+  final Random rand = randomSeed != null ? Random(randomSeed) : Random.secure();
   final String type = field.type.getDisplayString(withNullability: false);
   final String keyName = '_enviedkey${field.name}';
   final bool isNullable = allowOptional &&

--- a/packages/envied_generator/lib/src/generator.dart
+++ b/packages/envied_generator/lib/src/generator.dart
@@ -54,6 +54,7 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
           annotation.read('useConstantCase').literalValue as bool? ?? false,
       interpolate: annotation.read('interpolate').literalValue as bool? ?? true,
       rawStrings: annotation.read('rawStrings').literalValue as bool? ?? false,
+      randomSeed: annotation.read('randomSeed').literalValue as int?,
     );
 
     final Map<String, EnvVal> envs =
@@ -157,6 +158,8 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
             field,
             interpolate ? varValue?.interpolated : varValue?.raw,
             allowOptional: optional,
+            randomSeed: (reader.read('randomSeed').literalValue as int?) ??
+                config.randomSeed,
           )
         : generateFields(
             field,


### PR DESCRIPTION
Hello!
I'm using the obfuscate feature from clean builds in CI/CD, but every build is generating different output, so checks that I have for unchanged autogenerated files are failing.

My proposed solution is to provide optionally a seed for the random number generator.