### PR TITLE
chore: release v1.0.0

### DIFF
--- a/examples/envied_example/CHANGELOG.md
+++ b/examples/envied_example/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.0.2
+
+- Updates
+
+## 2.0.1
+
+- Refactor generator
+
+## 2.0.0
+
+- Update to Dart 3.0
+
 ## 1.0.0
 
 - Initial version.

--- a/examples/envied_example/pubspec.yaml
+++ b/examples/envied_example/pubspec.yaml
@@ -1,15 +1,15 @@
 name: example
-description: A sample command-line application.
-version: 2.0.1
+description: Envied example
+version: 2.0.2
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dev_dependencies:
   build_runner: ^2.4.6
-  envied_generator: ^0.5.2
-  lints: ^3.0.0
+  envied_generator: ^1.0.0
+  lints: ^5.0.0
   test: ^1.24.9
 dependencies:
-  envied: ^0.5.2
+  envied: ^1.0.0

--- a/melos.yaml
+++ b/melos.yaml
@@ -27,6 +27,6 @@ scripts:
   doc: >
     melos exec -c 1 --ignore="example/**" "dart doc ."
   env:
-    run: dart run scripts/propagate_readme.dart 
+    run: dart run scripts/propagate_readme.dart
     env:
       SYSTEM_VAR: 'system_var'

--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.0
 
  - **FEAT**: add support for custom seed when using Random during the obfuscation.
 

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,14 +1,14 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 0.5.4+1
+version: 1.0.0
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dev_dependencies:
-  lints: ">=2.1.1 <6.0.0"
+  lints: ">=4.0.0 <6.0.0"
   test: ^1.24.6
 
 topics:

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.0
 
  - **FEAT**: add support for custom seed when using Random during the obfuscation.
 

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,14 +1,14 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 0.5.4+1
+version: 1.0.0
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
-  envied: ^0.5.0
+  envied: ">=0.5.4+1 <2.0.0"
   build: ^2.4.1
   code_builder: ^4.8.0
   dart_style: ^2.3.2
@@ -18,7 +18,7 @@ dependencies:
   equatable: ^2.0.5
 
 dev_dependencies:
-  lints: ">=2.1.1 <6.0.0"
+  lints: ">=4.0.0 <6.0.0"
   test: ^1.24.6
   source_gen_test: ^1.0.6
 


### PR DESCRIPTION
## 2024-11-06

### Changes

---

Packages with breaking changes:

 - There are no breaking changes in this release.

### Packages with other changes:

 - [`envied` - `v1.0.0`](#envied---v100)
 - [`envied_generator` - `v1.0.0`](#enviedgenerator---v100)

---

#### `envied` - `v1.0.0`

 - **FEAT**: add support for custom seed when using Random during the obfuscation. (#116)

#### `envied_generator` - `v1.0.0`

 - **FEAT**: add support for custom seed when using Random during the obfuscation. (#116)