### PR TITLE
chore(deps)!: bump analyzer, source_gen, drop redundant dart_style in /packages/envied_generator

### DIFF
--- a/examples/envied_example/pubspec.lock
+++ b/examples/envied_example/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "45cfa8471b89fb6643fe9bf51bd7931a76b8f5ec2d65de4fb176dba8d4f22c77"
+      sha256: "88399e291da5f7e889359681a8f64b18c5123e03576b01f32a6a276611e511c3"
       url: "https://pub.dev"
     source: hosted
-    version: "73.0.0"
+    version: "78.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "4959fec185fe70cce007c57e9ab6983101dbe593d2bf8bbfb4453aaec0cf470a"
+      sha256: "62899ef43d0b962b056ed2ebac6b47ec76ffd003d5f7c4e4dc870afe63188e33"
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "7.1.0"
   args:
     dependency: transitive
     description:
@@ -50,50 +50,50 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
+      sha256: "294a2edaf4814a378725bfe6358210196f5ea37af89ecd81bfa32960113d4948"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.3"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: "99d3980049739a985cf9b21f30881f46db3ebc62c5b8d5e60e27440876b1ba1e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
+      sha256: "74691599a5bc750dc96a6b4bfd48f7d9d66453eab04c7f4063134800d6a5c573"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.13"
+    version: "2.4.14"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.2"
+    version: "8.0.0"
   built_collection:
     dependency: transitive
     description:
@@ -162,10 +162,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
+      sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.7"
+    version: "3.0.1"
   envied:
     dependency: "direct main"
     description:
@@ -240,10 +240,10 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "76d306a1c3afb33fe82e2bbacad62a61f409b5634c915fceb0d799de1a913360"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.2"
   io:
     dependency: transitive
     description:
@@ -272,10 +272,10 @@ packages:
     dependency: "direct dev"
     description:
       name: lints
-      sha256: "3315600f3fb3b135be672bf4a178c55f274bebe368325ae18462c89ac1e3b413"
+      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.1"
   logging:
     dependency: transitive
     description:
@@ -288,10 +288,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -360,10 +360,10 @@ packages:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "81876843eb50dc2e1e5b151792c9a985c5ed2536914115ed04e9c8528f6647b0"
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   recase:
     dependency: transitive
     description:
@@ -408,10 +408,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "2.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -448,10 +448,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "4ac0537115a24d772c408a2520ecd0abb99bca2ea9c4e634ccbdbfae64fe17ec"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -573,4 +573,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"

--- a/packages/envied_generator/lib/src/generator.dart
+++ b/packages/envied_generator/lib/src/generator.dart
@@ -6,7 +6,6 @@ import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:code_builder/code_builder.dart';
-import 'package:dart_style/dart_style.dart';
 import 'package:envied/envied.dart';
 import 'package:envied_generator/src/build_options.dart';
 import 'package:envied_generator/src/env_val.dart';
@@ -19,7 +18,7 @@ import 'package:source_gen/source_gen.dart';
 /// Generate code for classes annotated with the `@Envied()`.
 ///
 /// Will throw an [InvalidGenerationSourceError] if the annotated
-/// element is not a [classElement].
+/// element is not a [ClassElement].
 final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
   const EnviedGenerator(this._buildOptions);
 
@@ -54,7 +53,7 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
         '// ignore_for_file: type=lint\n'
         '// generated_from: $generatedFrom';
 
-    return DartFormatter().format('$ignore\n$generatedClassesAltogether');
+    return '$ignore\n$generatedClassesAltogether';
   }
 
   Future<String> _generateClassForEnviedAnnotation(

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -11,9 +11,8 @@ dependencies:
   envied: ^1.0.0
   build: ^2.4.1
   code_builder: ^4.8.0
-  dart_style: ^2.3.2
-  source_gen: ^1.4.0
-  analyzer: ">=5.1.0 <7.0.0"
+  source_gen: ^2.0.0
+  analyzer: ^7.0.0
   recase: ^4.1.0
   equatable: ^2.0.5
 

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
   envied: ^1.0.0
   build: ^2.4.1
   code_builder: ^4.8.0
-  source_gen: ^2.0.0
-  analyzer: ^7.0.0
+  source_gen: ">=1.4.0 <3.0.0"
+  analyzer: ">=5.1.0 <8.0.0"
   recase: ^4.1.0
   equatable: ^2.0.5
 

--- a/packages/envied_generator/test/src/generator_tests.dart
+++ b/packages/envied_generator/test/src/generator_tests.dart
@@ -279,11 +279,13 @@ abstract class Env11b {
 @ShouldGenerate(r'static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestString', contains: true)
 @ShouldGenerate(r'''
-  static final String testString = String.fromCharCodes(List<int>.generate(
-    _envieddatatestString.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]));
+  static final String testString = String.fromCharCodes(
+    List<int>.generate(
+      _envieddatatestString.length,
+      (int i) => i,
+      growable: false,
+    ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', obfuscate: true)
 abstract class Env12 {
@@ -294,11 +296,13 @@ abstract class Env12 {
 @ShouldGenerate(r'static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestString', contains: true)
 @ShouldGenerate(r'''
-  static final String? testString = String.fromCharCodes(List<int>.generate(
-    _envieddatatestString.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]));
+  static final String? testString = String.fromCharCodes(
+    List<int>.generate(
+      _envieddatatestString.length,
+      (int i) => i,
+      growable: false,
+    ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', obfuscate: true, allowOptionalFields: true)
 abstract class Env12b {
@@ -309,11 +313,13 @@ abstract class Env12b {
 @ShouldGenerate(r'static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestString', contains: true)
 @ShouldGenerate(r'''
-  static final String testString = String.fromCharCodes(List<int>.generate(
-    _envieddatatestString.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]));
+  static final String testString = String.fromCharCodes(
+    List<int>.generate(
+      _envieddatatestString.length,
+      (int i) => i,
+      growable: false,
+    ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', obfuscate: false)
 abstract class Env13 {
@@ -324,11 +330,13 @@ abstract class Env13 {
 @ShouldGenerate(r'static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestString', contains: true)
 @ShouldGenerate(r'''
-  static final String? testString = String.fromCharCodes(List<int>.generate(
-    _envieddatatestString.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]));
+  static final String? testString = String.fromCharCodes(
+    List<int>.generate(
+      _envieddatatestString.length,
+      (int i) => i,
+      growable: false,
+    ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', obfuscate: false, allowOptionalFields: true)
 abstract class Env13b {
@@ -482,11 +490,13 @@ abstract class Env16b {
 @ShouldGenerate(r'static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestString', contains: true)
 @ShouldGenerate(r'''
-  static final String testString = String.fromCharCodes(List<int>.generate(
-    _envieddatatestString.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]));
+  static final String testString = String.fromCharCodes(
+    List<int>.generate(
+      _envieddatatestString.length,
+      (int i) => i,
+      growable: false,
+    ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', obfuscate: true)
 abstract class Env17 {
@@ -497,11 +507,13 @@ abstract class Env17 {
 @ShouldGenerate(r'static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestString', contains: true)
 @ShouldGenerate(r'''
-  static final String? testString = String.fromCharCodes(List<int>.generate(
-    _envieddatatestString.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]));
+  static final String? testString = String.fromCharCodes(
+    List<int>.generate(
+      _envieddatatestString.length,
+      (int i) => i,
+      growable: false,
+    ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', obfuscate: true, allowOptionalFields: true)
 abstract class Env17b {
@@ -512,11 +524,13 @@ abstract class Env17b {
 @ShouldGenerate(r'static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestString', contains: true)
 @ShouldGenerate(r'''
-  static final String testString = String.fromCharCodes(List<int>.generate(
-    _envieddatatestString.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]));
+  static final String testString = String.fromCharCodes(
+    List<int>.generate(
+      _envieddatatestString.length,
+      (int i) => i,
+      growable: false,
+    ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', obfuscate: false)
 abstract class Env18 {
@@ -527,11 +541,13 @@ abstract class Env18 {
 @ShouldGenerate(r'static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestString', contains: true)
 @ShouldGenerate(r'''
-  static final String? testString = String.fromCharCodes(List<int>.generate(
-    _envieddatatestString.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]));
+  static final String? testString = String.fromCharCodes(
+    List<int>.generate(
+      _envieddatatestString.length,
+      (int i) => i,
+      growable: false,
+    ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', obfuscate: false, allowOptionalFields: true)
 abstract class Env18b {
@@ -542,11 +558,13 @@ abstract class Env18b {
 @ShouldGenerate(r'static const List<int> _enviedkeytestString', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestString', contains: true)
 @ShouldGenerate(r'''
-  static final String? testString = String.fromCharCodes(List<int>.generate(
-    _envieddatatestString.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]));
+  static final String? testString = String.fromCharCodes(
+    List<int>.generate(
+      _envieddatatestString.length,
+      (int i) => i,
+      growable: false,
+    ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', obfuscate: false, allowOptionalFields: true)
 abstract class Env18c {
@@ -602,11 +620,13 @@ abstract class Env20b {
 @ShouldGenerate(r'static const List<int> _envieddatatestDynamic',
     contains: true)
 @ShouldGenerate(r'''
-  static final testDynamic = String.fromCharCodes(List<int>.generate(
-    _envieddatatestDynamic.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestDynamic[i] ^ _enviedkeytestDynamic[i]));
+  static final testDynamic = String.fromCharCodes(
+    List<int>.generate(
+      _envieddatatestDynamic.length,
+      (int i) => i,
+      growable: false,
+    ).map((int i) => _envieddatatestDynamic[i] ^ _enviedkeytestDynamic[i]),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example')
 abstract class Env21 {
@@ -740,11 +760,15 @@ abstract class Env29bInvalid {
 @ShouldGenerate(r'static const List<int> _enviedkeytestUrl', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestUrl', contains: true)
 @ShouldGenerate(r'''
-  static final Uri testUrl = Uri.parse(String.fromCharCodes(List<int>.generate(
-    _envieddatatestUrl.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestUrl[i] ^ _enviedkeytestUrl[i])));
+  static final Uri testUrl = Uri.parse(
+    String.fromCharCodes(
+      List<int>.generate(
+        _envieddatatestUrl.length,
+        (int i) => i,
+        growable: false,
+      ).map((int i) => _envieddatatestUrl[i] ^ _enviedkeytestUrl[i]),
+    ),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example')
 abstract class Env29c {
@@ -762,11 +786,15 @@ abstract class Env29cInvalid {
 @ShouldGenerate(r'static const List<int> _enviedkeytestUrl', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestUrl', contains: true)
 @ShouldGenerate(r'''
-  static final Uri? testUrl = Uri.parse(String.fromCharCodes(List<int>.generate(
-    _envieddatatestUrl.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestUrl[i] ^ _enviedkeytestUrl[i])));
+  static final Uri? testUrl = Uri.parse(
+    String.fromCharCodes(
+      List<int>.generate(
+        _envieddatatestUrl.length,
+        (int i) => i,
+        growable: false,
+      ).map((int i) => _envieddatatestUrl[i] ^ _enviedkeytestUrl[i]),
+    ),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', allowOptionalFields: true)
 abstract class Env29d {
@@ -800,8 +828,9 @@ abstract class Env29empty {
 // ignore_for_file: type=lint
 // generated_from: test/.env.example
 final class _Env30 {
-  static final DateTime testDateTime =
-      DateTime.parse('2023-11-06T22:32:55.287Z');
+  static final DateTime testDateTime = DateTime.parse(
+    '2023-11-06T22:32:55.287Z',
+  );
 }
 ''')
 @Envied(path: 'test/.env.example')
@@ -815,8 +844,9 @@ abstract class Env30 {
 // ignore_for_file: type=lint
 // generated_from: test/.env.example
 final class _Env30b {
-  static final DateTime? testDateTime =
-      DateTime.parse('2023-11-06T22:32:55.287Z');
+  static final DateTime? testDateTime = DateTime.parse(
+    '2023-11-06T22:32:55.287Z',
+  );
 }
 ''')
 @Envied(path: 'test/.env.example', allowOptionalFields: true)
@@ -830,12 +860,15 @@ abstract class Env30b {
 @ShouldGenerate(r'static const List<int> _envieddatatestDateTime',
     contains: true)
 @ShouldGenerate(r'''
-  static final DateTime testDateTime =
-      DateTime.parse(String.fromCharCodes(List<int>.generate(
-    _envieddatatestDateTime.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestDateTime[i] ^ _enviedkeytestDateTime[i])));
+  static final DateTime testDateTime = DateTime.parse(
+    String.fromCharCodes(
+      List<int>.generate(
+        _envieddatatestDateTime.length,
+        (int i) => i,
+        growable: false,
+      ).map((int i) => _envieddatatestDateTime[i] ^ _enviedkeytestDateTime[i]),
+    ),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example')
 abstract class Env30c {
@@ -848,12 +881,15 @@ abstract class Env30c {
 @ShouldGenerate(r'static const List<int> _envieddatatestDateTime',
     contains: true)
 @ShouldGenerate(r'''
-  static final DateTime? testDateTime =
-      DateTime.parse(String.fromCharCodes(List<int>.generate(
-    _envieddatatestDateTime.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestDateTime[i] ^ _enviedkeytestDateTime[i])));
+  static final DateTime? testDateTime = DateTime.parse(
+    String.fromCharCodes(
+      List<int>.generate(
+        _envieddatatestDateTime.length,
+        (int i) => i,
+        growable: false,
+      ).map((int i) => _envieddatatestDateTime[i] ^ _enviedkeytestDateTime[i]),
+    ),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', allowOptionalFields: true)
 abstract class Env30d {
@@ -928,12 +964,15 @@ abstract class Env31b {
 @ShouldGenerate(r'static const List<int> _enviedkeytestDate', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestDate', contains: true)
 @ShouldGenerate(r'''
-  static final DateTime testDate =
-      DateTime.parse(String.fromCharCodes(List<int>.generate(
-    _envieddatatestDate.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestDate[i] ^ _enviedkeytestDate[i])));
+  static final DateTime testDate = DateTime.parse(
+    String.fromCharCodes(
+      List<int>.generate(
+        _envieddatatestDate.length,
+        (int i) => i,
+        growable: false,
+      ).map((int i) => _envieddatatestDate[i] ^ _enviedkeytestDate[i]),
+    ),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example')
 abstract class Env31c {
@@ -944,12 +983,15 @@ abstract class Env31c {
 @ShouldGenerate(r'static const List<int> _enviedkeytestDate', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestDate', contains: true)
 @ShouldGenerate(r'''
-  static final DateTime? testDate =
-      DateTime.parse(String.fromCharCodes(List<int>.generate(
-    _envieddatatestDate.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestDate[i] ^ _enviedkeytestDate[i])));
+  static final DateTime? testDate = DateTime.parse(
+    String.fromCharCodes(
+      List<int>.generate(
+        _envieddatatestDate.length,
+        (int i) => i,
+        growable: false,
+      ).map((int i) => _envieddatatestDate[i] ^ _enviedkeytestDate[i]),
+    ),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', allowOptionalFields: true)
 abstract class Env31d {
@@ -988,12 +1030,15 @@ abstract class Env31dInvalid {
 @ShouldGenerate(r'static const List<int> _enviedkeytestDouble', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestDouble', contains: true)
 @ShouldGenerate(r'''
-  static final double testDouble =
-      double.parse(String.fromCharCodes(List<int>.generate(
-    _envieddatatestDouble.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestDouble[i] ^ _enviedkeytestDouble[i])));
+  static final double testDouble = double.parse(
+    String.fromCharCodes(
+      List<int>.generate(
+        _envieddatatestDouble.length,
+        (int i) => i,
+        growable: false,
+      ).map((int i) => _envieddatatestDouble[i] ^ _enviedkeytestDouble[i]),
+    ),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example')
 abstract class Env32a {
@@ -1004,12 +1049,15 @@ abstract class Env32a {
 @ShouldGenerate(r'static const List<int> _enviedkeytestDouble', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestDouble', contains: true)
 @ShouldGenerate(r'''
-  static final double? testDouble =
-      double.parse(String.fromCharCodes(List<int>.generate(
-    _envieddatatestDouble.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestDouble[i] ^ _enviedkeytestDouble[i])));
+  static final double? testDouble = double.parse(
+    String.fromCharCodes(
+      List<int>.generate(
+        _envieddatatestDouble.length,
+        (int i) => i,
+        growable: false,
+      ).map((int i) => _envieddatatestDouble[i] ^ _enviedkeytestDouble[i]),
+    ),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', allowOptionalFields: true)
 abstract class Env32b {
@@ -1020,11 +1068,15 @@ abstract class Env32b {
 @ShouldGenerate(r'static const List<int> _enviedkeytestNum', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestNum', contains: true)
 @ShouldGenerate(r'''
-  static final num testNum = num.parse(String.fromCharCodes(List<int>.generate(
-    _envieddatatestNum.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestNum[i] ^ _enviedkeytestNum[i])));
+  static final num testNum = num.parse(
+    String.fromCharCodes(
+      List<int>.generate(
+        _envieddatatestNum.length,
+        (int i) => i,
+        growable: false,
+      ).map((int i) => _envieddatatestNum[i] ^ _enviedkeytestNum[i]),
+    ),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example')
 abstract class Env33a {
@@ -1035,11 +1087,15 @@ abstract class Env33a {
 @ShouldGenerate(r'static const List<int> _enviedkeytestNum', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestNum', contains: true)
 @ShouldGenerate(r'''
-  static final num? testNum = num.parse(String.fromCharCodes(List<int>.generate(
-    _envieddatatestNum.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestNum[i] ^ _enviedkeytestNum[i])));
+  static final num? testNum = num.parse(
+    String.fromCharCodes(
+      List<int>.generate(
+        _envieddatatestNum.length,
+        (int i) => i,
+        growable: false,
+      ).map((int i) => _envieddatatestNum[i] ^ _enviedkeytestNum[i]),
+    ),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', allowOptionalFields: true)
 abstract class Env33b {
@@ -1116,12 +1172,15 @@ abstract class Env35b {
 @ShouldGenerate(r'static const List<int> _enviedkeytestEnum', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestEnum', contains: true)
 @ShouldGenerate(r'''
-  static final ExampleEnum testEnum =
-      ExampleEnum.values.byName(String.fromCharCodes(List<int>.generate(
-    _envieddatatestEnum.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestEnum[i] ^ _enviedkeytestEnum[i])));
+  static final ExampleEnum testEnum = ExampleEnum.values.byName(
+    String.fromCharCodes(
+      List<int>.generate(
+        _envieddatatestEnum.length,
+        (int i) => i,
+        growable: false,
+      ).map((int i) => _envieddatatestEnum[i] ^ _enviedkeytestEnum[i]),
+    ),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example')
 abstract class Env35c {
@@ -1132,12 +1191,15 @@ abstract class Env35c {
 @ShouldGenerate(r'static const List<int> _enviedkeytestEnum', contains: true)
 @ShouldGenerate(r'static const List<int> _envieddatatestEnum', contains: true)
 @ShouldGenerate(r'''
-  static final ExampleEnum? testEnum =
-      ExampleEnum.values.byName(String.fromCharCodes(List<int>.generate(
-    _envieddatatestEnum.length,
-    (int i) => i,
-    growable: false,
-  ).map((int i) => _envieddatatestEnum[i] ^ _enviedkeytestEnum[i])));
+  static final ExampleEnum? testEnum = ExampleEnum.values.byName(
+    String.fromCharCodes(
+      List<int>.generate(
+        _envieddatatestEnum.length,
+        (int i) => i,
+        growable: false,
+      ).map((int i) => _envieddatatestEnum[i] ^ _enviedkeytestEnum[i]),
+    ),
+  );
 ''', contains: true)
 @Envied(path: 'test/.env.example', allowOptionalFields: true)
 abstract class Env35d {
@@ -1186,8 +1248,9 @@ abstract class Env35dInvalid {
 // ignore_for_file: type=lint
 // generated_from: test/.env.example
 final class _Env36 {
-  static final Uri testQueryVars =
-      Uri.parse('https://www.my-awesome-website.com/index.php?foo=bar&baz=qux');
+  static final Uri testQueryVars = Uri.parse(
+    'https://www.my-awesome-website.com/index.php?foo=bar&baz=qux',
+  );
 }
 ''')
 @Envied(path: 'test/.env.example')


### PR DESCRIPTION
A mock Dependabot PR that supersedes #128.

---

These dependencies need to be updated together.

Bumps [analyzer](https://github.com/dart-lang/sdk/tree/main/pkg/analyzer) from >=5.1.0 <7.0.0 to 7.1.0.

Bumps [dart_style](https://github.com/dart-lang/dart_style) from  2.3.2 to 3.0.1.
- [Release notes](https://github.com/dart-lang/dart_style/releases)
- [Commits](https://github.com/dart-lang/dart_style/compare/v2.3.2...v3.0.1)

Bumps [source_gen](https://github.com/dart-lang/source_gen) from 1.5.0 to 2.0.0.
- [Release notes](https://github.com/dart-lang/source_gen/releases)
- [Commits](https://github.com/dart-lang/source_gen/compare/source_gen-v1.5.0...source_gen-v2.0.0)

---
updated-dependencies:
- dependency-name: analyzer
  dependency-type: direct:production
  update-type: version-update:semver-major
- dependency-name: dart_style
  dependency-type: direct:production
  update-type: version-update:semver-major
- dependency-name: source_gen
  dependency-type: direct:production
  update-type: version-update:semver-major

---

Closes #128