### PR TITLE
chore: release v1.0.1

### DIFF
--- a/examples/envied_example/pubspec.lock
+++ b/examples/envied_example/pubspec.lock
@@ -172,14 +172,14 @@ packages:
       path: "../../packages/envied"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   envied_generator:
     dependency: "direct dev"
     description:
       path: "../../packages/envied_generator"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   equatable:
     dependency: transitive
     description:

--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,6 +1,11 @@
+## 1.0.1
+
+- **FEAT**: multiple generations for same class (#124)
+- **FEAT**: allow reading System env key from .env files (#120)
+
 ## 1.0.0
 
- - **FEAT**: add support for custom seed when using Random during the obfuscation.
+ - **FEAT**: add support for custom seed when using Random during the obfuscation (#116)
 
 ## 0.5.4+1
 

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,6 +1,11 @@
+## 1.0.1
+
+ - **FEAT**: multiple generations for same class (#124)
+ - **FEAT**: allow reading System env key from .env files (#120)
+
 ## 1.0.0
 
- - **FEAT**: add support for custom seed when using Random during the obfuscation.
+ - **FEAT**: add support for custom seed when using Random during the obfuscation (#116)
 
 ## 0.5.4+1
 

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  envied: ">=0.5.4+1 <2.0.0"
+  envied: ^1.0.0
   build: ^2.4.1
   code_builder: ^4.8.0
   dart_style: ^2.3.2


### PR DESCRIPTION
## 2025-01-14

### Changes

---

Packages with breaking changes:

 - There are no breaking changes in this release.

### Packages with other changes:

 - [`envied` - `v1.0.1`](#envied---v101)
 - [`envied_generator` - `v1.0.1`](#enviedgenerator---v101)

---

#### `envied` - `v1.0.1`

- **FEAT**: multiple generations for same class (#124)
- **FEAT**: allow reading System env key from .env files (#120)

#### `envied_generator` - `v1.0.1`

- **FEAT**: multiple generations for same class (#124)
- **FEAT**: allow reading System env key from .env files (#120)