### PR TITLE
fix: multiple generations for same class

### DIFF
--- a/examples/envied_example/analysis_options.yaml
+++ b/examples/envied_example/analysis_options.yaml
@@ -1,30 +1,5 @@
-# This file configures the static analysis results for your project (errors,
-# warnings, and lints).
-#
-# This enables the 'recommended' set of lints from `package:lints`.
-# This set helps identify many issues that may lead to problems when running
-# or consuming Dart code, and enforces writing Dart using a single, idiomatic
-# style and format.
-#
-# If you want a smaller set of lints you can change this to specify
-# 'package:lints/core.yaml'. These are just the most critical lints
-# (the recommended set includes the core lints).
-# The core lints are also what is used by pub.dev for scoring packages.
-
 include: package:lints/recommended.yaml
 
-# Uncomment the following section to specify additional rules.
-
-# linter:
-#   rules:
-#     - camel_case_types
-
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
-
-# For more information about the core and recommended set of lints, see
-# https://dart.dev/go/core-lints
-
-# For additional information about configuring this file, see
-# https://dart.dev/guides/language/analysis-options
+analyzer:
+  language:
+    strict-casts: true

--- a/examples/envied_example/lib/app_env.dart
+++ b/examples/envied_example/lib/app_env.dart
@@ -7,7 +7,7 @@ abstract interface class AppEnv implements AppEnvFields {
   ///
   /// In a Flutter app you would normally import this like so
   /// import 'package:flutter/foundation.dart';
-  static const kDebugMode = true;
+  static const bool kDebugMode = true;
 
   factory AppEnv() => _instance;
 

--- a/examples/envied_example/lib/envs.env.dart
+++ b/examples/envied_example/lib/envs.env.dart
@@ -23,11 +23,11 @@ final class Envs implements AppEnvFields {
   ///
   /// In a Flutter app you would normally import this like so
   /// import 'package:flutter/foundation.dart';
-  static const kDebugMode = true;
+  static const bool kDebugMode = true;
 
   factory Envs() => _instance;
 
-  static final dynamic _instance = kDebugMode ? _Dev() : _Prod();
+  static final Envs _instance = kDebugMode ? _Dev() : _Prod();
 
   @override
   @EnviedField(varName: 'KEY1')

--- a/examples/envied_example/lib/envs.env.g.dart
+++ b/examples/envied_example/lib/envs.env.g.dart
@@ -10,41 +10,59 @@ part of 'envs.env.dart';
 // ignore_for_file: type=lint
 // generated_from: .env_debug
 final class _Dev implements Envs {
+  @override
   final String key1 = r'debug_foo';
 
+  @override
   final String key2 = r'debug_bar';
 
+  @override
   final String key3 = r'debug_baz';
 
+  @override
   final int key4 = 456;
 
+  @override
   final bool key5 = true;
 
+  @override
   final Uri key6 = Uri.parse('http://zomg.test/bbq');
 
+  @override
   final DateTime key7 = DateTime.parse('2022-09-01T12:01:12.001Z');
 
+  @override
   final ExampleEnum key8 = ExampleEnum.values.byName('ipsum');
 
+  @override
   final String key9 = r'unescaped$';
 }
 
 final class _Prod implements Envs {
+  @override
   final String key1 = 'foo';
 
+  @override
   final String key2 = 'bar';
 
+  @override
   final String key3 = 'baz';
 
+  @override
   final int key4 = 123;
 
+  @override
   final bool key5 = false;
 
+  @override
   final Uri key6 = Uri.parse('http://foo.bar/baz');
 
+  @override
   final DateTime key7 = DateTime.parse('2023-11-06T23:09:51.123Z');
 
+  @override
   final ExampleEnum key8 = ExampleEnum.values.byName('lorem');
 
+  @override
   final String key9 = r'uneascaped$';
 }

--- a/examples/envied_example/lib/envs.env.g.dart
+++ b/examples/envied_example/lib/envs.env.g.dart
@@ -8,42 +8,43 @@ part of 'envs.env.dart';
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-final class _Dev {
-  static const String key1 = r'debug_foo';
+// generated_from: .env_debug
+final class _Dev implements Envs {
+  final String key1 = r'debug_foo';
 
-  static const String key2 = r'debug_bar';
+  final String key2 = r'debug_bar';
 
-  static const String key3 = r'debug_baz';
+  final String key3 = r'debug_baz';
 
-  static const int key4 = 456;
+  final int key4 = 456;
 
-  static const bool key5 = true;
+  final bool key5 = true;
 
-  static final Uri key6 = Uri.parse('http://zomg.test/bbq');
+  final Uri key6 = Uri.parse('http://zomg.test/bbq');
 
-  static final DateTime key7 = DateTime.parse('2022-09-01T12:01:12.001Z');
+  final DateTime key7 = DateTime.parse('2022-09-01T12:01:12.001Z');
 
-  static final ExampleEnum key8 = ExampleEnum.values.byName('ipsum');
+  final ExampleEnum key8 = ExampleEnum.values.byName('ipsum');
 
-  static const String key9 = r'unescaped$';
+  final String key9 = r'unescaped$';
 }
 
-final class _Prod {
-  static const String key1 = 'foo';
+final class _Prod implements Envs {
+  final String key1 = 'foo';
 
-  static const String key2 = 'bar';
+  final String key2 = 'bar';
 
-  static const String key3 = 'baz';
+  final String key3 = 'baz';
 
-  static const int key4 = 123;
+  final int key4 = 123;
 
-  static const bool key5 = false;
+  final bool key5 = false;
 
-  static final Uri key6 = Uri.parse('http://foo.bar/baz');
+  final Uri key6 = Uri.parse('http://foo.bar/baz');
 
-  static final DateTime key7 = DateTime.parse('2023-11-06T23:09:51.123Z');
+  final DateTime key7 = DateTime.parse('2023-11-06T23:09:51.123Z');
 
-  static final ExampleEnum key8 = ExampleEnum.values.byName('lorem');
+  final ExampleEnum key8 = ExampleEnum.values.byName('lorem');
 
-  static const String key9 = r'uneascaped$';
+  final String key9 = r'uneascaped$';
 }

--- a/examples/envied_example/lib/example.dart
+++ b/examples/envied_example/lib/example.dart
@@ -1,4 +1,5 @@
 import 'package:example/env.dart';
+import 'package:example/envs.env.dart';
 
 void run() {
   print(Env.key1);
@@ -6,4 +7,5 @@ void run() {
   print(Env.key3);
   print(Env.key4);
   print(Env.key5);
+  print(Envs().key1);
 }

--- a/packages/envied_generator/lib/src/generate_field.dart
+++ b/packages/envied_generator/lib/src/generate_field.dart
@@ -148,6 +148,9 @@ Iterable<Field> generateFields(
   return [
     Field(
       (FieldBuilder fieldBuilder) => fieldBuilder
+        ..annotations.addAll([
+          if (multipleAnnotations) refer('override'),
+        ])
         ..static = !multipleAnnotations
         ..modifier = !multipleAnnotations ? modifier : FieldModifier.final$
         ..type = field.type is! DynamicType

--- a/packages/envied_generator/lib/src/generate_field.dart
+++ b/packages/envied_generator/lib/src/generate_field.dart
@@ -16,6 +16,7 @@ Iterable<Field> generateFields(
   String? value, {
   bool allowOptional = false,
   bool rawString = false,
+  bool multipleAnnotations = false,
 }) {
   final String type = field.type.getDisplayString(withNullability: false);
 
@@ -147,8 +148,8 @@ Iterable<Field> generateFields(
   return [
     Field(
       (FieldBuilder fieldBuilder) => fieldBuilder
-        ..static = true
-        ..modifier = modifier
+        ..static = !multipleAnnotations
+        ..modifier = !multipleAnnotations ? modifier : FieldModifier.final$
         ..type = field.type is! DynamicType
             ? refer(field.type.getDisplayString(withNullability: allowOptional))
             : null

--- a/packages/envied_generator/lib/src/generate_field_encrypted.dart
+++ b/packages/envied_generator/lib/src/generate_field_encrypted.dart
@@ -19,6 +19,7 @@ Iterable<Field> generateFieldsEncrypted(
   String? value, {
   bool allowOptional = false,
   int? randomSeed,
+  bool multipleAnnotations = false,
 }) {
   final Random rand = randomSeed != null ? Random(randomSeed) : Random.secure();
   final String type = field.type.getDisplayString(withNullability: false);
@@ -277,7 +278,7 @@ Iterable<Field> generateFieldsEncrypted(
       ),
       Field(
         (FieldBuilder fieldBuilder) => fieldBuilder
-          ..static = true
+          ..static = !multipleAnnotations
           ..modifier = FieldModifier.final$
           ..type = field.type is! DynamicType
               ? TypeReference(

--- a/packages/envied_generator/lib/src/generate_field_encrypted.dart
+++ b/packages/envied_generator/lib/src/generate_field_encrypted.dart
@@ -278,6 +278,9 @@ Iterable<Field> generateFieldsEncrypted(
       ),
       Field(
         (FieldBuilder fieldBuilder) => fieldBuilder
+          ..annotations.addAll([
+            if (multipleAnnotations) refer('override'),
+          ])
           ..static = !multipleAnnotations
           ..modifier = FieldModifier.final$
           ..type = field.type is! DynamicType

--- a/packages/envied_generator/test/src/generator_tests.dart
+++ b/packages/envied_generator/test/src/generator_tests.dart
@@ -1370,14 +1370,17 @@ abstract class Env37e {
 // ignore_for_file: type=lint
 // generated_from: test/.env.example
 final class _Foo implements Env38 {
+  @override
   final String testString = 'test_string';
 }
 
 final class _Bar implements Env38 {
+  @override
   final String testString = 'test_string';
 }
 
 final class _Env38 implements Env38 {
+  @override
   final String testString = 'test_string';
 }
 ''')
@@ -1395,6 +1398,7 @@ abstract class Env38 {
 @ShouldGenerate(r'final class _Bar implements Env39', contains: true)
 @ShouldGenerate(r'final class _Env39 implements Env39', contains: true)
 @ShouldGenerate(r'''
+  @override
   final String testString = String.fromCharCodes(
     List<int>.generate(
       _envieddatatestString.length,

--- a/packages/envied_generator/test/src/generator_tests.dart
+++ b/packages/envied_generator/test/src/generator_tests.dart
@@ -1388,3 +1388,25 @@ abstract class Env38 {
   @EnviedField(varName: 'test_string')
   final String? testString = null;
 }
+
+@ShouldGenerate(r'static const List<int> _enviedkeytestString', contains: true)
+@ShouldGenerate(r'static const List<int> _envieddatatestString', contains: true)
+@ShouldGenerate(r'final class _Foo implements Env39', contains: true)
+@ShouldGenerate(r'final class _Bar implements Env39', contains: true)
+@ShouldGenerate(r'final class _Env39 implements Env39', contains: true)
+@ShouldGenerate(r'''
+  final String testString = String.fromCharCodes(
+    List<int>.generate(
+      _envieddatatestString.length,
+      (int i) => i,
+      growable: false,
+    ).map((int i) => _envieddatatestString[i] ^ _enviedkeytestString[i]),
+  );
+''', contains: true)
+@Envied(path: 'test/.env.example', name: 'Foo', obfuscate: true)
+@Envied(path: 'test/.env.example', name: 'Bar', obfuscate: true)
+@Envied(path: 'test/.env.example', obfuscate: true)
+abstract class Env39 {
+  @EnviedField()
+  static const String? testString = null;
+}

--- a/packages/envied_generator/test/src/generator_tests.dart
+++ b/packages/envied_generator/test/src/generator_tests.dart
@@ -1369,16 +1369,16 @@ abstract class Env37e {
 // coverage:ignore-file
 // ignore_for_file: type=lint
 // generated_from: test/.env.example
-final class _Foo {
-  static const String testString = 'test_string';
+final class _Foo implements Env38 {
+  final String testString = 'test_string';
 }
 
-final class _Bar {
-  static const String testString = 'test_string';
+final class _Bar implements Env38 {
+  final String testString = 'test_string';
 }
 
-final class _Env38 {
-  static const String testString = 'test_string';
+final class _Env38 implements Env38 {
+  final String testString = 'test_string';
 }
 ''')
 @Envied(path: 'test/.env.example', name: 'Foo')
@@ -1386,5 +1386,5 @@ final class _Env38 {
 @Envied(path: 'test/.env.example')
 abstract class Env38 {
   @EnviedField(varName: 'test_string')
-  static const String? testString = null;
+  final String? testString = null;
 }


### PR DESCRIPTION
This pull request includes several changes to the `envied_example` and `envied_generator` packages to improve type safety, add support for multiple annotations, and update the generated code structure. The most important changes include modifying the `AppEnv` and `Envs` classes, updating the `generateFields` and `generateFieldsEncrypted` functions, and enhancing the `EnviedGenerator` class to handle multiple annotations.

### Type Safety Improvements:
* [`examples/envied_example/lib/app_env.dart`](diffhunk://#diff-eb6fc84a6085143dc7ba473385a8a214fa5c3ac3ba9de80469df7bdaa79dfbcbL10-R10): Changed `kDebugMode` to explicitly use `bool` type.
* [`examples/envied_example/lib/envs.env.dart`](diffhunk://#diff-358efa9199d705c949c43991ef125addcf944dc48f20375cd0302a323565d3daL26-R30): Updated `kDebugMode` to explicitly use `bool` type and modified `_instance` to use `Envs` type.

### Support for Multiple Annotations:
* [`packages/envied_generator/lib/src/generate_field.dart`](diffhunk://#diff-43283a9344f98ddc8d3b65b4522c2f6e86fbc0fd0baa19cb85841fbefe1b1136R19): Added `multipleAnnotations` parameter to `generateFields` function and updated field generation logic to handle multiple annotations. [[1]](diffhunk://#diff-43283a9344f98ddc8d3b65b4522c2f6e86fbc0fd0baa19cb85841fbefe1b1136R19) [[2]](diffhunk://#diff-43283a9344f98ddc8d3b65b4522c2f6e86fbc0fd0baa19cb85841fbefe1b1136L150-R155)
* [`packages/envied_generator/lib/src/generate_field_encrypted.dart`](diffhunk://#diff-1b43ffc92fbe6a8e5824fa4943872e161df24cb2ecf1b4b49c8447cf03d6c5d3R22): Added `multipleAnnotations` parameter to `generateFieldsEncrypted` function and updated field generation logic to handle multiple annotations. [[1]](diffhunk://#diff-1b43ffc92fbe6a8e5824fa4943872e161df24cb2ecf1b4b49c8447cf03d6c5d3R22) [[2]](diffhunk://#diff-1b43ffc92fbe6a8e5824fa4943872e161df24cb2ecf1b4b49c8447cf03d6c5d3L280-R284)

### Enhancements to EnviedGenerator:
* [`packages/envied_generator/lib/src/generator.dart`](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caR39-R50): Enhanced `EnviedGenerator` class to handle multiple annotations by updating `_generateClassForEnviedAnnotation` method and adding `multipleAnnotations` parameter. [[1]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caR39-R50) [[2]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caL59-R71) [[3]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caL108-L116) [[4]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caR143) [[5]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caR228-R235)

### Code Structure Updates:
* [`examples/envied_example/lib/envs.env.g.dart`](diffhunk://#diff-8a31b662c0ec1524f98580207bd02a134d037b0c120b8b518f67f2f17fbff5b7L11-R67): Updated `_Dev` and `_Prod` classes to implement `Envs` interface and added `@override` annotations for fields.
* [`examples/envied_example/lib/example.dart`](diffhunk://#diff-77815ac09216f6bdb496abb516af0dc69250ac074c87c8b265f44c48f5104ac1R2-R10): Added import for `envs.env.dart` and included a print statement for `Envs().key1`.

These changes collectively enhance the type safety, flexibility, and maintainability of the codebase.

---

Enhances #123, #124
Fixes #133, #134