### PR TITLE
docs: add mention about `override` parameter when setting path through CLI

### DIFF
--- a/packages/envied/README.md
+++ b/packages/envied/README.md
@@ -281,6 +281,16 @@ To change which `.env` file is used by default using the CLI, pass it in via the
 dart run build_runner build --define=envied_generator:envied=path=my_other.env
 ```
 
+And also set the `override` parameter to `true` inside `build.yaml` file. Without it `envied` always uses the default `.env` path.
+```yaml
+targets:
+  $default:
+    builders:
+      envied_generator|envied:
+        options:
+          override: true 
+```
+
 This allows you to have multiple `.env` files, one per backend for instance, and then switch which one gets included in the build easily from CI/CD scripts such as github workflows.
 
 ### Known issues


### PR DESCRIPTION
Hi! 👋 😄 
This PR addresses that issue https://github.com/petercinibulk/envied/issues/139#issuecomment-2664747950.
So the lack of information in README that user has to set `override` parameter to true in `build.yaml` in order to say `envied` that it should use path given in CLI e.g.
```shell
dart run build_runner build --define=envied_generator:envied=path=my_other.env
```
Without setting `override` parameter, `envied` sticks to the default `.env` path.