### PR TITLE
chore: migrate to analyzer Element2 model

### DIFF
--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 1.1.1
+version: 1.2.0
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
@@ -8,8 +8,8 @@ environment:
   sdk: ^3.0.0
 
 dev_dependencies:
-  lints: ">=4.0.0 <7.0.0"
-  test: ^1.24.6
+  lints: ^6.0.0
+  test: ^1.26.3
 
 topics:
   - environment-variables

--- a/packages/envied_generator/lib/src/extensions.dart
+++ b/packages/envied_generator/lib/src/extensions.dart
@@ -1,29 +1,30 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 extension DartTypeExtension on DartType {
   /// Return `true` if this type represents the type 'Uri' defined in the
   /// dart:core library.
   bool get isDartCoreUri =>
-      element?.name == 'Uri' && element?.library?.isDartCore == true;
+      element3?.name3 == 'Uri' && element3?.library2?.isDartCore == true;
 
   /// Return `true` if this type represents the type 'DateTime' defined in the
   /// dart:core library.
   bool get isDartCoreDateTime =>
-      element?.name == 'DateTime' && element?.library?.isDartCore == true;
+      element3?.name3 == 'DateTime' && element3?.library2?.isDartCore == true;
 
   /// Return `true` if the type extends the type 'Enum'.
   /// Unlike `isDartCoreEnum` it is not not restricted to the dart:core library.
-  bool get isDartEnum => element is EnumElement;
+  bool get isDartEnum => element3 is EnumElement2;
 }
 
-extension EnumElementExtension on EnumElement {
+extension EnumElementExtension on EnumElement2 {
   /// Return the fields defined in this enum.
-  Iterable<FieldElement> get values =>
-      fields.where((FieldElement fe) => fe.isEnumConstant);
+  Iterable<FieldElement2> get values =>
+      fields2.where((FieldElement2 fe) => fe.isEnumConstant);
 
   /// Return the names of the values defined by this enum.
-  Iterable<String> get valueNames => values.map((FieldElement fe) => fe.name);
+  Iterable<String> get valueNames =>
+      values.map((FieldElement2 fe) => fe.name3!);
 }
 
 /// Taken from https://stackoverflow.com/questions/76038472/limit-string-split-to-a-maximum-number-of-elements#answer-76039017

--- a/packages/envied_generator/lib/src/generate_field.dart
+++ b/packages/envied_generator/lib/src/generate_field.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:envied_generator/src/extensions.dart';
@@ -12,7 +12,7 @@ import 'package:source_gen/source_gen.dart';
 /// an [InvalidGenerationSourceError] will also be thrown if
 /// the type can't be casted, or is not supported.
 Iterable<Field> generateFields(
-  FieldElement field,
+  FieldElement2 field,
   String? value, {
   bool allowOptional = false,
   bool rawString = false,
@@ -26,7 +26,7 @@ Iterable<Field> generateFields(
   if (value == null) {
     if (!allowOptional) {
       throw InvalidGenerationSourceError(
-        'Environment variable not found for field `${field.name}`.',
+        'Environment variable not found for field `${field.name3}`.',
         element: field,
       );
     }
@@ -113,7 +113,7 @@ Iterable<Field> generateFields(
         ],
       );
     } else if (field.type.isDartEnum) {
-      final EnumElement enumElement = field.type.element as EnumElement;
+      final EnumElement2 enumElement = field.type.element3 as EnumElement2;
 
       if (!enumElement.valueNames.contains(value)) {
         throw InvalidGenerationSourceError(
@@ -156,7 +156,7 @@ Iterable<Field> generateFields(
         ..type = field.type is! DynamicType
             ? refer(field.type.getDisplayString(withNullability: allowOptional))
             : null
-        ..name = field.name
+        ..name = field.name3
         ..assignment = result.code,
     ),
   ];

--- a/packages/envied_generator/lib/src/generate_field_encrypted.dart
+++ b/packages/envied_generator/lib/src/generate_field_encrypted.dart
@@ -1,6 +1,6 @@
 import 'dart:math' show Random;
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
@@ -15,7 +15,7 @@ import 'package:source_gen/source_gen.dart';
 /// an [InvalidGenerationSourceError] will also be thrown if
 /// the type can't be casted, or is not supported.
 Iterable<Field> generateFieldsEncrypted(
-  FieldElement field,
+  FieldElement2 field,
   String? value, {
   bool allowOptional = false,
   int? randomSeed,
@@ -23,14 +23,14 @@ Iterable<Field> generateFieldsEncrypted(
 }) {
   final Random rand = randomSeed != null ? Random(randomSeed) : Random.secure();
   final String type = field.type.getDisplayString(withNullability: false);
-  final String keyName = '_enviedkey${field.name}';
+  final String keyName = '_enviedkey${field.name3}';
   final bool isNullable = allowOptional &&
       field.type.nullabilitySuffix == NullabilitySuffix.question;
 
   if (value == null) {
     if (!allowOptional) {
       throw InvalidGenerationSourceError(
-        'Environment variable not found for field `${field.name}`.',
+        'Environment variable not found for field `${field.name3}`.',
         element: field,
       );
     }
@@ -61,7 +61,7 @@ Iterable<Field> generateFieldsEncrypted(
           ..type = field.type is! DynamicType
               ? refer(field.type.getDisplayString(withNullability: true))
               : null
-          ..name = field.name
+          ..name = field.name3
           ..assignment = literalNull.code,
       ),
     ];
@@ -98,7 +98,7 @@ Iterable<Field> generateFieldsEncrypted(
               ..symbol = 'int'
               ..isNullable = isNullable,
           )
-          ..name = field.name
+          ..name = field.name3
           ..assignment =
               refer(keyName).operatorBitwiseXor(literalNum(encValue)).code,
       ),
@@ -136,7 +136,7 @@ Iterable<Field> generateFieldsEncrypted(
               ..symbol = 'bool'
               ..isNullable = isNullable,
           )
-          ..name = field.name
+          ..name = field.name3
           ..assignment =
               refer(keyName).operatorBitwiseXor(literalBool(encValue)).code,
       ),
@@ -161,7 +161,7 @@ Iterable<Field> generateFieldsEncrypted(
     }
 
     if (field.type.isDartEnum) {
-      final EnumElement enumElement = field.type.element as EnumElement;
+      final EnumElement2 enumElement = field.type.element3 as EnumElement2;
 
       if (!enumElement.valueNames.contains(value)) {
         throw InvalidGenerationSourceError(
@@ -181,7 +181,7 @@ Iterable<Field> generateFieldsEncrypted(
     final List<int> encValue = [
       for (int i = 0; i < parsed.length; i++) parsed[i] ^ key[i]
     ];
-    final String encName = '_envieddata${field.name}';
+    final String encName = '_envieddata${field.name3}';
     final Expression stringExpression = refer('String').type.newInstanceNamed(
       'fromCharCodes',
       [
@@ -290,7 +290,7 @@ Iterable<Field> generateFieldsEncrypted(
                     ..isNullable = isNullable,
                 )
               : null
-          ..name = field.name
+          ..name = field.name3
           ..assignment = result.code,
       ),
     ];

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 1.1.1
+version: 1.2.0
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
@@ -8,18 +8,18 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  envied: ^1.1.0
-  build: ^2.4.1
-  code_builder: ^4.8.0
-  source_gen: ">=1.4.0 <3.0.0"
-  analyzer: ">=5.1.0 <8.0.0"
+  envied: ^1.1.1
+  build: ^3.0.0
+  code_builder: ^4.10.1
+  source_gen: ^3.0.0
+  analyzer: ">=7.4.0 <8.0.0"
   recase: ^4.1.0
-  equatable: ^2.0.5
+  equatable: ^2.0.7
 
 dev_dependencies:
-  lints: ">=4.0.0 <7.0.0"
-  test: ^1.24.6
-  source_gen_test: ^1.0.6
+  lints: ^6.0.0
+  test: ^1.26.3
+  source_gen_test: ^1.3.0
 
 topics:
   - environment-variables

--- a/packages/envied_generator/test/src/generator_tests.dart
+++ b/packages/envied_generator/test/src/generator_tests.dart
@@ -21,7 +21,7 @@ final class _Env0 {}
 abstract class Env0 {}
 
 @ShouldThrow(
-  "Environment variable file doesn't exist at `${const String.fromEnvironment('ENV_PATH', defaultValue: '.env')}`.",
+  "Environment variable file doesn't exist at `${String.fromEnvironment('ENV_PATH', defaultValue: '.env')}`.",
 )
 @Envied(requireEnvFile: true)
 abstract class Env1 {}


### PR DESCRIPTION
This pull request introduces significant updates to the `envied` and `envied_generator` packages, focusing on upgrading dependencies, adapting to breaking changes in the `analyzer` package, and improving compatibility with Dart SDK 3.0.0. The most notable changes include updating the dependency versions, replacing deprecated APIs from the `analyzer` package, and making adjustments to maintain compatibility with the latest source generation tools.

### Dependency Updates and Version Bumps:
* Updated the version of `envied` and `envied_generator` to `1.2.0` in their respective `pubspec.yaml` files. This includes upgrading dependencies such as `analyzer` to `>=7.4.0 <8.0.0`, `source_gen` to `^3.0.0`, and `build` to `^3.0.0` to ensure compatibility with Dart SDK 3.0.0. [[1]](diffhunk://#diff-0ab64f02a4548fe7b0b2ec6930cb927fb8d736ede8a22bb0694d71bef993baacL3-R12) [[2]](diffhunk://#diff-acb232fc5faa8303647cace24c98bffa46bbdc289002a3d6b1de5c73b1061212L3-R22)

### Migration to New `analyzer` APIs:
* Replaced deprecated `Element` and `FieldElement` classes with `Element2` and `FieldElement2` throughout the codebase. Updated related APIs such as `element`, `fields`, and `name` to their new counterparts (`element2`, `fields2`, and `name3`). [[1]](diffhunk://#diff-e50a67b28ee3c70b92de374097fc1b8fda78985287317f4126c49aacaa359a41L1-R27) [[2]](diffhunk://#diff-43283a9344f98ddc8d3b65b4522c2f6e86fbc0fd0baa19cb85841fbefe1b1136L1-R1) [[3]](diffhunk://#diff-1b43ffc92fbe6a8e5824fa4943872e161df24cb2ecf1b4b49c8447cf03d6c5d3L3-R3) [[4]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caL4-R4)
* Adjusted type-checking and field generation logic in `generateFields`, `generateFieldsEncrypted`, and `_generateFields` methods to use the updated APIs. [[1]](diffhunk://#diff-43283a9344f98ddc8d3b65b4522c2f6e86fbc0fd0baa19cb85841fbefe1b1136L15-R15) [[2]](diffhunk://#diff-43283a9344f98ddc8d3b65b4522c2f6e86fbc0fd0baa19cb85841fbefe1b1136L116-R116) [[3]](diffhunk://#diff-1b43ffc92fbe6a8e5824fa4943872e161df24cb2ecf1b4b49c8447cf03d6c5d3L18-R33) [[4]](diffhunk://#diff-1b43ffc92fbe6a8e5824fa4943872e161df24cb2ecf1b4b49c8447cf03d6c5d3L184-R184) [[5]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caL140-R140)

### Code Refactoring for Compatibility:
* Updated error messages and string interpolation to use the new `name3` property for fields and elements. [[1]](diffhunk://#diff-43283a9344f98ddc8d3b65b4522c2f6e86fbc0fd0baa19cb85841fbefe1b1136L29-R29) [[2]](diffhunk://#diff-1b43ffc92fbe6a8e5824fa4943872e161df24cb2ecf1b4b49c8447cf03d6c5d3L101-R101) [[3]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caL173-R180)
* Adjusted class and field handling logic in `EnviedGenerator` to accommodate changes in the `analyzer` package, ensuring proper handling of annotations and class elements. [[1]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caL67-L79) [[2]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caL115-R124)

### Test Updates:
* Updated test cases to reflect changes in string interpolation and error messages caused by the migration to the new `analyzer` APIs.

These changes ensure the `envied` and `envied_generator` packages remain compatible with the latest Dart and Flutter ecosystems while addressing breaking changes in the `analyzer` package.