### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-07-26
+
+ ### Changes
+
+ ---
+
+ Packages with breaking changes:
+
+  - There are no breaking changes in this release.
+
+ ### Packages with other changes:
+
+  - [`envied` - `v1.2.0`](#envied---v120)
+  - [`envied_generator` - `v1.2.0`](#enviedgenerator---v120)
+
+ ---
+
+ #### `envied` - `v1.2.0`
+
+  - **CHORE**: migrate to analyzer Element2 model (#151)
+
+ #### `envied_generator` - `v1.2.0`
+
+  - **CHORE**: migrate to analyzer Element2 model (#151)
+
 ## 2025-02-06
 
 ### Changes

--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+ - **CHORE**: migrate to analyzer Element2 model (#151)
+
 ## 1.1.1
 
  - **FIX**: multiple generations for same class (#136)

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 1.1.1
+version: 1.2.0
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+ - **CHORE**: migrate to analyzer Element2 model (#151)
+
 ## 1.1.1
 
  - **FIX**: multiple generations for same class (#136)

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 1.1.1
+version: 1.2.0
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: "envied_monorepo"
 publish_to: none
 
 dev_dependencies:
-  melos: ^6.3.2
+  melos: ^6.3.3
   path: ^1.9.1
   yaml: ^3.1.3
 


### PR DESCRIPTION
## 2025-07-26

 ### Changes

 ---

 Packages with breaking changes:

  - There are no breaking changes in this release.

 ### Packages with other changes:

  - [`envied` - `v1.2.0`](#envied---v120)
  - [`envied_generator` - `v1.2.0`](#enviedgenerator---v120)

 ---

 #### `envied` - `v1.2.0`

  - **CHORE**: migrate to analyzer Element2 model (#151)

 #### `envied_generator` - `v1.2.0`

  - **CHORE**: migrate to analyzer Element2 model (#151)