### PR TITLE
chore: release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,30 +3,55 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-08-20
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+### Packages with other changes:
+
+ - [`envied` - `v1.2.1`](#envied---v121)
+ - [`envied_generator` - `v1.2.1`](#enviedgenerator---v121)
+
+---
+
+#### `envied` - `v1.2.1`
+
+ - **CHORE**: update analyzer dependency to `>=7.4.0 <9.0.0`
+
+#### `envied_generator` - `v1.2.1`
+
+ - **CHORE**: update analyzer dependency to `>=7.4.0 <9.0.0`
+
 ## 2025-07-26
 
- ### Changes
+### Changes
 
- ---
+---
 
- Packages with breaking changes:
+Packages with breaking changes:
 
-  - There are no breaking changes in this release.
+ - There are no breaking changes in this release.
 
- ### Packages with other changes:
+### Packages with other changes:
 
-  - [`envied` - `v1.2.0`](#envied---v120)
-  - [`envied_generator` - `v1.2.0`](#enviedgenerator---v120)
+ - [`envied` - `v1.2.0`](#envied---v120)
+ - [`envied_generator` - `v1.2.0`](#enviedgenerator---v120)
 
- ---
+---
 
- #### `envied` - `v1.2.0`
+#### `envied` - `v1.2.0`
 
-  - **CHORE**: migrate to analyzer Element2 model (#151)
+ - **CHORE**: migrate to analyzer Element2 model (#151)
 
- #### `envied_generator` - `v1.2.0`
+#### `envied_generator` - `v1.2.0`
 
-  - **CHORE**: migrate to analyzer Element2 model (#151)
+ - **CHORE**: migrate to analyzer Element2 model (#151)
 
 ## 2025-02-06
 

--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+- **CHORE**: update analyzer dependency to `>=7.4.0 <9.0.0`
+
 ## 1.2.0
 
  - **CHORE**: migrate to analyzer Element2 model (#151)

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 1.2.0
+version: 1.2.1
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+- **CHORE**: update analyzer dependency to `>=7.4.0 <9.0.0`
+
 ## 1.2.0
 
  - **CHORE**: migrate to analyzer Element2 model (#151)

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 1.2.0
+version: 1.2.1
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 


### PR DESCRIPTION
This pull request updates both the `envied` and `envied_generator` packages to version `1.2.1`, focusing on dependency maintenance. The main change is relaxing the version constraint for the `analyzer` dependency to support newer versions, ensuring compatibility with the latest analyzer releases.

Dependency updates:

* Updated the `analyzer` dependency constraint to `>=7.4.0 <9.0.0` in both `envied` and `envied_generator` packages (`pubspec.yaml` files). [[1]](diffhunk://#diff-0ab64f02a4548fe7b0b2ec6930cb927fb8d736ede8a22bb0694d71bef993baacL3-R3) [[2]](diffhunk://#diff-acb232fc5faa8303647cace24c98bffa46bbdc289002a3d6b1de5c73b1061212L3-R3)
* Documented the dependency update in the changelogs for both packages (`CHANGELOG.md`). [[1]](diffhunk://#diff-fd735a2acf953a6047d6f30cf168e707ff8c08610c58167ba54aa87cf905740fR1-R4) [[2]](diffhunk://#diff-157a3a2f0637d3ea599cdbce6f9b5748cc0aac0cee57497ef964aad2af4c385eR1-R4)

Release information:

* Updated the main project changelog to reflect the new `1.2.1` release for both packages and confirmed there are no breaking changes.