### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-09-15
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+### Packages with other changes:
+
+ - [`envied` - `v1.3.0`](#envied---v130)
+ - [`envied_generator` - `v1.3.0`](#enviedgenerator---v130)
+
+#### `envied` - `v1.3.0`
+
+ - **CHORE**: broaden version constraints for `build` and `source_gen` dependencies
+
+#### `envied_generator` - `v1.3.0`
+
+ - **CHORE**: broaden version constraints for `build` and `source_gen` dependencies
+
 ## 2025-08-20
 
 ### Changes

--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+- **CHORE**: broaden version constraints for `build` and `source_gen` dependencies
+
 ## 1.2.1
 
 - **CHORE**: update analyzer dependency to `>=7.4.0 <9.0.0`

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 1.2.1
+version: 1.3.0
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+- **CHORE**: broaden version constraints for `build` and `source_gen` dependencies
+
 ## 1.2.1
 
 - **CHORE**: update analyzer dependency to `>=7.4.0 <9.0.0`

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 1.2.1
+version: 1.3.0
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
@@ -11,7 +11,7 @@ dependencies:
   analyzer: ">=7.4.0 <9.0.0"
   build: ">=3.1.0 <5.0.0"
   code_builder: ^4.11.0
-  envied: ^1.1.1
+  envied: ^1.2.1
   equatable: ^2.0.7
   recase: ^4.1.0
   source_gen: ">=3.1.0 <5.0.0"


### PR DESCRIPTION
This pull request updates both the `envied` and `envied_generator` packages to version 1.3.0, focusing on broadening the version constraints for their `build` and `source_gen` dependencies to improve compatibility with newer versions. There are no breaking changes in this release.

Dependency updates:

* Broadened version constraints for the `build` and `source_gen` dependencies in both `envied` and `envied_generator` to allow for greater flexibility and compatibility with future versions.

Version bump and changelog:

* Bumped the version of `envied` and `envied_generator` to 1.3.0 in their respective `pubspec.yaml` files and added corresponding entries to their `CHANGELOG.md` files. [[1]](diffhunk://#diff-0ab64f02a4548fe7b0b2ec6930cb927fb8d736ede8a22bb0694d71bef993baacL3-R3) [[2]](diffhunk://#diff-acb232fc5faa8303647cace24c98bffa46bbdc289002a3d6b1de5c73b1061212L3-R3) [[3]](diffhunk://#diff-fd735a2acf953a6047d6f30cf168e707ff8c08610c58167ba54aa87cf905740fR1-R4) [[4]](diffhunk://#diff-157a3a2f0637d3ea599cdbce6f9b5748cc0aac0cee57497ef964aad2af4c385eR1-R4)

Project changelog:

* Updated the main `CHANGELOG.md` to reflect the new release, specifying that there are no breaking changes and summarizing the dependency updates.