### PR TITLE
chore: remove `dart:io` from envied

### DIFF
--- a/packages/envied/lib/src/envied_base.dart
+++ b/packages/envied/lib/src/envied_base.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 /// Annotation with default options
 const envied = Envied();
 


### PR DESCRIPTION
The import is unnecessary as far as I can tell.
In fact, removing this single import should mark `envied` as compatible with Web - because I was wondering why it should not be compatible with Web (after reading #161)