### PR TITLE
chore: release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-09-26
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+### Packages with other changes:
+
+ - [`envied` - `v1.3.1`](#envied---v131)
+ - [`envied_generator` - `v1.3.1`](#enviedgenerator---v131)
+
+#### `envied` - `v1.3.1`
+
+ - **CHORE**: remove `dart:io` import
+
+#### `envied_generator` - `v1.3.1`
+
+ - **CHORE**: require `envied` version `^1.3.0`
+
 ## 2025-09-15
 
 ### Changes

--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+- **CHORE**: remove `dart:io` import (#165)
+
 ## 1.3.0
 
 - **CHORE**: broaden version constraints for `build` and `source_gen` dependencies

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 1.3.0
+version: 1.3.1
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+- **CHORE**: require `envied` version `^1.3.0`
+
 ## 1.3.0
 
 - **CHORE**: broaden version constraints for `build` and `source_gen` dependencies

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 1.3.0
+version: 1.3.1
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
@@ -11,7 +11,7 @@ dependencies:
   analyzer: ">=7.4.0 <9.0.0"
   build: ">=3.1.0 <5.0.0"
   code_builder: ^4.11.0
-  envied: ^1.2.1
+  envied: ^1.3.0
   equatable: ^2.0.7
   recase: ^4.1.0
   source_gen: ">=3.1.0 <5.0.0"


### PR DESCRIPTION
## 2025-09-26

### Changes

---

Packages with breaking changes:

 - There are no breaking changes in this release.

### Packages with other changes:

 - [`envied` - `v1.3.1`](#envied---v131)
 - [`envied_generator` - `v1.3.1`](#enviedgenerator---v131)

#### `envied` - `v1.3.1`

 - **CHORE**: remove `dart:io` import

#### `envied_generator` - `v1.3.1`

 - **CHORE**: require `envied` version `^1.3.0`