### PR TITLE
docs: Remove $ from README dart pub command

### DIFF
--- a/packages/envied/README.md
+++ b/packages/envied/README.md
@@ -86,7 +86,7 @@ print(Env.key); // "VALUE"
 Add both `envied` and `envied_generator` as dependencies,
 
 ```sh
-$ dart pub add envied dev:envied_generator dev:build_runner
+dart pub add envied dev:envied_generator dev:build_runner
 ```
 
 This installs three packages:


### PR DESCRIPTION
If you use the copy button on github or pub.dev you get `$ dart pub add envied dev:envied_generator dev:build_runner` copied to your clipboard which isn't usable as a command.