### PR TITLE
chore: release v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-11-23
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+### Packages with other changes:
+
+ - [`envied` - `v1.3.2`](#envied---v132)
+ - [`envied_generator` - `v1.3.2`](#enviedgenerator---v132)
+
+#### `envied` - `v1.3.2`
+
+ - **CHORE**: add support for `analyzer` 9.0.0 (#172)
+
+#### `envied_generator` - `v1.3.2`
+
+ - **CHORE**: add support for `analyzer` 9.0.0 (#172)
+
 ## 2025-09-26
 
 ### Changes

--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2
+
+- **CHORE**: add support for `analyzer` 9.0.0 (#172)
+
 ## 1.3.1
 
 - **CHORE**: remove `dart:io` import (#165)

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 1.3.1
+version: 1.3.2
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2
+
+- **CHORE**: add support for `analyzer` 9.0.0 (#172)
+
 ## 1.3.1
 
 - **CHORE**: require `envied` version `^1.3.0`

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: envied_generator
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 1.3.1
+version: 1.3.2
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 


### PR DESCRIPTION
## 2025-11-23

### Changes

---

Packages with breaking changes:

 - There are no breaking changes in this release.

### Packages with other changes:

 - [`envied` - `v1.3.2`](#envied---v132)
 - [`envied_generator` - `v1.3.2`](#enviedgenerator---v132)

#### `envied` - `v1.3.2`

 - **CHORE**: add support for `analyzer` 9.0.0 (#172)

#### `envied_generator` - `v1.3.2`

 - **CHORE**: add support for `analyzer` 9.0.0 (#172)