### PR TITLE
feat: add pathOverrides support for Envied annotations

### DIFF
--- a/packages/envied/README.md
+++ b/packages/envied/README.md
@@ -315,6 +315,35 @@ targets:
 This allows you to have multiple `.env` files, one per backend for instance, and then switch which one gets included in 
 the build easily from CI/CD scripts such as github workflows.
 
+The `path` option is a global override. When `override` is `true`, it replaces every `@Envied` annotation path used by
+the builder.
+
+For classes with multiple `@Envied` annotations, use `pathOverrides` to set paths independently:
+
+```yaml
+targets:
+  $default:
+    builders:
+      envied_generator|envied:
+        options:
+          override: true
+          pathOverrides:
+            ProductionEnv: .env.production
+            DebugEnv: .env.debug
+```
+
+You can also pass `pathOverrides` from the CLI. The value must be JSON so `build_runner` can parse it as a map:
+
+```sh
+dart run build_runner build \
+  --define=envied_generator:envied=override=true \
+  --define='envied_generator:envied=pathOverrides={"ProductionEnv":".env.production","DebugEnv":".env.debug"}'
+```
+
+`pathOverrides` keys are matched against `@Envied(name)` first, then the original `@Envied(path)`. If no
+`pathOverrides` entry matches, envied falls back to the global `path` override when set, and then to the annotation path.
+Empty override values are ignored.
+
 ### Multiple environments
 
 Say you need to have different environments for debug, and production and have 2 different `.env` files 

--- a/packages/envied_generator/lib/src/build_options.dart
+++ b/packages/envied_generator/lib/src/build_options.dart
@@ -9,16 +9,54 @@
 ///       envied_generator|envied:
 ///         options:
 ///           path: .env.test
+///           pathOverrides:
+///             ProductionEnv: .env.production
+///             DebugEnv: .env.debug
 ///           override: true
 /// ```
 class BuildOptions {
-  const BuildOptions({this.override, this.path});
+  const BuildOptions({this.override, this.path, this.pathOverrides = const {}});
 
   final String? path;
+  final Map<String, String> pathOverrides;
   final bool? override;
 
   factory BuildOptions.fromMap(Map<String, dynamic> map) => BuildOptions(
     override: map['override'] as bool?,
     path: map['path'] as String?,
+    pathOverrides: _parsePathOverrides(map['pathOverrides']),
   );
+
+  static Map<String, String> _parsePathOverrides(Object? pathOverrides) {
+    if (pathOverrides == null) {
+      return const {};
+    }
+
+    if (pathOverrides is! Map) {
+      throw ArgumentError.value(
+        pathOverrides,
+        'pathOverrides',
+        'Expected a map with string keys and string values.',
+      );
+    }
+
+    final Map<String, String> parsed = <String, String>{};
+
+    for (final MapEntry<dynamic, dynamic> entry in pathOverrides.entries) {
+      final dynamic key = entry.key;
+      final dynamic value = entry.value;
+
+      if (key is! String || value is! String) {
+        throw ArgumentError.value(
+          pathOverrides,
+          'pathOverrides',
+          'Expected a map with string keys and string values.',
+        );
+      }
+
+      parsed[key] = value;
+    }
+
+    return Map<String, String>.unmodifiable(parsed);
+  }
 }

--- a/packages/envied_generator/lib/src/generator.dart
+++ b/packages/envied_generator/lib/src/generator.dart
@@ -39,9 +39,7 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
       );
     }
 
-    final Iterable<ConstantReader> enviedAnnotations = element
-        .metadata
-        .annotations
+    final List<ConstantReader> enviedAnnotations = element.metadata.annotations
         .where(
           (ElementAnnotation annotation) =>
               annotation.element?.displayName == 'Envied',
@@ -49,7 +47,8 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
         .map(
           (ElementAnnotation annotation) =>
               ConstantReader(annotation.computeConstantValue()),
-        );
+        )
+        .toList(growable: false);
 
     final bool multipleAnnotations = enviedAnnotations.length > 1;
 
@@ -66,10 +65,7 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
       );
     }
 
-    final String? generatedFrom =
-        _buildOptions.override == true && _buildOptions.path?.isNotEmpty == true
-        ? _buildOptions.path
-        : annotation.read('path').literalValue as String?;
+    final String generatedFrom = _generatedFrom(enviedAnnotations);
 
     final String ignore =
         '// coverage:ignore-file\n'
@@ -79,6 +75,19 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
     return '$ignore\n$generatedClassesAltogether';
   }
 
+  String _generatedFrom(Iterable<ConstantReader> annotations) {
+    final List<String> paths = <String>[];
+
+    for (final ConstantReader annotation in annotations) {
+      final String path = _resolvePath(annotation);
+      if (!paths.contains(path)) {
+        paths.add(path);
+      }
+    }
+
+    return paths.join(', ');
+  }
+
   Future<String> _generateClassForEnviedAnnotation({
     required ClassElement element,
     required ConstantReader annotation,
@@ -86,11 +95,7 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
     bool multipleAnnotations = false,
   }) async {
     final Envied config = Envied(
-      path:
-          _buildOptions.override == true &&
-              _buildOptions.path?.isNotEmpty == true
-          ? _buildOptions.path
-          : annotation.read('path').literalValue as String?,
+      path: _resolvePath(annotation),
       requireEnvFile:
           annotation.read('requireEnvFile').literalValue as bool? ?? false,
       name: annotation.read('name').literalValue as String?,
@@ -142,6 +147,38 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
 
     return cls.accept(emitter).toString();
   }
+
+  String _resolvePath(ConstantReader annotation) {
+    final String annotationPath =
+        annotation.read('path').literalValue as String? ?? '.env';
+
+    if (_buildOptions.override != true) {
+      return annotationPath;
+    }
+
+    final String? annotationName = _nonEmpty(
+      annotation.read('name').literalValue as String?,
+    );
+
+    final String? nameOverride = annotationName == null
+        ? null
+        : _nonEmpty(_buildOptions.pathOverrides[annotationName]);
+    if (nameOverride != null) {
+      return nameOverride;
+    }
+
+    final String? pathOverride = _nonEmpty(
+      _buildOptions.pathOverrides[annotationPath],
+    );
+    if (pathOverride != null) {
+      return pathOverride;
+    }
+
+    return _nonEmpty(_buildOptions.path) ?? annotationPath;
+  }
+
+  static String? _nonEmpty(String? value) =>
+      value?.isNotEmpty == true ? value : null;
 
   static TypeChecker _typeChecker(
     Type type, {

--- a/packages/envied_generator/test/.env.path_overrides_annotation
+++ b/packages/envied_generator/test/.env.path_overrides_annotation
@@ -1,0 +1,1 @@
+value=annotation

--- a/packages/envied_generator/test/.env.path_overrides_debug
+++ b/packages/envied_generator/test/.env.path_overrides_debug
@@ -1,0 +1,1 @@
+value=debug

--- a/packages/envied_generator/test/.env.path_overrides_fallback
+++ b/packages/envied_generator/test/.env.path_overrides_fallback
@@ -1,0 +1,1 @@
+value=fallback

--- a/packages/envied_generator/test/.env.path_overrides_global
+++ b/packages/envied_generator/test/.env.path_overrides_global
@@ -1,0 +1,1 @@
+value=global

--- a/packages/envied_generator/test/.env.path_overrides_production
+++ b/packages/envied_generator/test/.env.path_overrides_production
@@ -1,0 +1,1 @@
+value=production

--- a/packages/envied_generator/test/build_options_test.dart
+++ b/packages/envied_generator/test/build_options_test.dart
@@ -1,0 +1,47 @@
+import 'package:envied_generator/src/build_options.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BuildOptions', () {
+    test('parses pathOverrides', () {
+      final BuildOptions options = BuildOptions.fromMap(<String, dynamic>{
+        'pathOverrides': <String, dynamic>{
+          'ProductionEnv': '.env.production',
+          'DebugEnv': '.env.debug',
+        },
+      });
+
+      expect(options.pathOverrides, <String, String>{
+        'ProductionEnv': '.env.production',
+        'DebugEnv': '.env.debug',
+      });
+    });
+
+    test('throws when pathOverrides is not a map', () {
+      expect(
+        () => BuildOptions.fromMap(<String, dynamic>{
+          'pathOverrides': '.env.production',
+        }),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws when pathOverrides contains non-string values', () {
+      expect(
+        () => BuildOptions.fromMap(<String, dynamic>{
+          'pathOverrides': <String, dynamic>{'ProductionEnv': 1},
+        }),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws when pathOverrides contains non-string keys', () {
+      expect(
+        () => BuildOptions.fromMap(<String, dynamic>{
+          'pathOverrides': <dynamic, String>{1: '.env.production'},
+        }),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/packages/envied_generator/test/envy_generator_test.dart
+++ b/packages/envied_generator/test/envy_generator_test.dart
@@ -28,4 +28,41 @@ Future<void> main() async {
       ),
     ),
   );
+
+  testAnnotatedElements(
+    await initializeLibraryReaderForDirectory(
+      'test/src',
+      'generator_tests_with_path_overrides.dart',
+    ),
+    EnviedGenerator(
+      const BuildOptions(
+        path: 'test/.env.path_overrides_global',
+        pathOverrides: <String, String>{
+          'ProductionEnv': 'test/.env.path_overrides_production',
+          'DebugEnv': 'test/.env.path_overrides_debug',
+          'test/.env.path_overrides_annotation':
+              'test/.env.path_overrides_fallback',
+        },
+        override: true,
+      ),
+    ),
+  );
+
+  testAnnotatedElements(
+    await initializeLibraryReaderForDirectory(
+      'test/src',
+      'generator_tests_with_path_overrides_disabled.dart',
+    ),
+    EnviedGenerator(
+      const BuildOptions(
+        path: 'test/.env.path_overrides_global',
+        pathOverrides: <String, String>{
+          'ProductionEnv': 'test/.env.path_overrides_production',
+          'test/.env.path_overrides_annotation':
+              'test/.env.path_overrides_fallback',
+        },
+        override: false,
+      ),
+    ),
+  );
 }

--- a/packages/envied_generator/test/src/generator_tests_with_path_overrides.dart
+++ b/packages/envied_generator/test/src/generator_tests_with_path_overrides.dart
@@ -1,0 +1,53 @@
+// ignore_for_file: unnecessary_nullable_for_final_variable_declarations
+
+import 'package:envied/envied.dart';
+import 'package:source_gen_test/annotations.dart';
+
+@ShouldGenerate(r'''
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// generated_from: test/.env.path_overrides_production, test/.env.path_overrides_debug
+final class _ProductionEnv implements EnvWithPathOverridesByName {
+  @override
+  final String value = 'production';
+}
+
+final class _DebugEnv implements EnvWithPathOverridesByName {
+  @override
+  final String value = 'debug';
+}
+''')
+@Envied(path: 'test/.env.path_overrides_annotation', name: 'ProductionEnv')
+@Envied(path: 'test/.env.path_overrides_annotation', name: 'DebugEnv')
+abstract class EnvWithPathOverridesByName {
+  @EnviedField()
+  final String? value = null;
+}
+
+@ShouldGenerate(r'''
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// generated_from: test/.env.path_overrides_fallback
+final class _PathFallbackEnv {
+  static const String value = 'fallback';
+}
+''')
+@Envied(path: 'test/.env.path_overrides_annotation', name: 'PathFallbackEnv')
+abstract class EnvWithPathOverridesByPath {
+  @EnviedField()
+  static const String? value = null;
+}
+
+@ShouldGenerate(r'''
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// generated_from: test/.env.path_overrides_global
+final class _GlobalFallbackEnv {
+  static const String value = 'global';
+}
+''')
+@Envied(path: 'test/.env.path_overrides_not_used', name: 'GlobalFallbackEnv')
+abstract class EnvWithPathOverridesGlobalFallback {
+  @EnviedField()
+  static const String? value = null;
+}

--- a/packages/envied_generator/test/src/generator_tests_with_path_overrides_disabled.dart
+++ b/packages/envied_generator/test/src/generator_tests_with_path_overrides_disabled.dart
@@ -1,0 +1,18 @@
+// ignore_for_file: unnecessary_nullable_for_final_variable_declarations
+
+import 'package:envied/envied.dart';
+import 'package:source_gen_test/annotations.dart';
+
+@ShouldGenerate(r'''
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// generated_from: test/.env.path_overrides_annotation
+final class _ProductionEnv {
+  static const String value = 'annotation';
+}
+''')
+@Envied(path: 'test/.env.path_overrides_annotation', name: 'ProductionEnv')
+abstract class EnvWithPathOverridesDisabled {
+  @EnviedField()
+  static const String? value = null;
+}


### PR DESCRIPTION
## Summary

- Add `pathOverrides` builder option for per-`@Envied` path overrides.
- Keep existing global `path` override behavior unchanged.
- Resolve override paths by `@Envied(name)` first, then original annotation path, then global `path`, then annotation/default path.
- Document YAML and CLI usage for `pathOverrides`.

### Addresses
- #169 