### PR TITLE
chore(deps): update analyzer dependency range

### DIFF
--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  analyzer: ">=8.0.0 <13.0.0"
+  analyzer: ">=8.0.0 <14.0.0"
   build: ^4.0.3
   code_builder: ^4.11.0
   envied: ^1.3.3


### PR DESCRIPTION
This pull request updates the version constraint for the `analyzer` package in the `packages/envied_generator/pubspec.yaml` file to allow compatibility with newer versions.

Dependency updates:

* Expanded the supported version range for the `analyzer` dependency from `<13.0.0` to `<14.0.0` to allow use with analyzer versions up to, but not including, 14.0.0.