### PR TITLE
feat: add .env inheritance support in Envied and EnviedGenerator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ melos_envied_monorepo.iml
 .packages
 .fvm
 pubspec.lock
+.history
+.DS_Store

--- a/packages/envied/README.md
+++ b/packages/envied/README.md
@@ -36,6 +36,7 @@ A cleaner way to handle your environment variables in Dart/Flutter.
   - [**Optional Environment Variables**](#optional-environment-variables)
   - [**Environment Variable Naming Conventions**](#environment-variable-naming-conventions)
   - [Using System Environment Variables](#using-system-environment-variables)
+  - [Environment inheritance](#environment-inheritance)
   - [Setting file from CLI](#setting-file-from-cli)
   - [Multiple environments](#multiple-environments)
 - [Known Issues](#known-issues)
@@ -291,6 +292,41 @@ files to be safely checked in to the source control, the specific values to be s
 safely stored in the host environment.
 
 For instructions on switching the `.env` file at build time, see [Setting file from CLI](#setting-file-from-cli).
+
+### Environment inheritance
+
+Use `inheritFrom` to share default values across multiple `.env` files. Envied
+loads inherited files from left to right, then loads the file specified by
+`path`. Values in later files override earlier files.
+
+**.env.defaults**
+```.env
+API_URL=https://api.example.com
+TIMEOUT=30
+```
+
+**.env.dev**
+```.env
+API_URL=https://dev-api.example.com
+```
+
+```dart
+@Envied(path: '.env.dev', inheritFrom: ['.env.defaults'])
+abstract class Env {
+  @EnviedField()
+  static const String apiUrl = _Env.apiUrl;
+
+  @EnviedField()
+  static const int timeout = _Env.timeout;
+}
+```
+
+In this example, `apiUrl` is read from `.env.dev`, while `timeout` falls back
+to `.env.defaults`.
+
+When using a build configuration `path` override, the override changes only the
+primary `path`. Files listed in `inheritFrom` are still loaded from the
+annotation.
 
 ### Setting file from CLI
 

--- a/packages/envied/lib/src/envied_base.dart
+++ b/packages/envied/lib/src/envied_base.dart
@@ -9,6 +9,12 @@ final class Envied {
   /// If `null` or an empty [String], `.env` is used.
   final String path;
 
+  /// Paths of `.env` files to load before [path].
+  ///
+  /// Values from later files override values from earlier files, so values in
+  /// [path] override values from inherited files.
+  final List<String> inheritFrom;
+
   /// Whether to require a env file exists, or else the build_runner will fail if the file does not exits
   final bool requireEnvFile;
 
@@ -100,6 +106,7 @@ final class Envied {
 
   const Envied({
     String? path,
+    this.inheritFrom = const <String>[],
     bool? requireEnvFile,
     this.name,
     this.obfuscate = false,

--- a/packages/envied/lib/src/envied_base.dart
+++ b/packages/envied/lib/src/envied_base.dart
@@ -116,7 +116,7 @@ final class Envied {
     this.interpolate = true,
     this.rawStrings = false,
     this.randomSeed,
-  }) : path = path ?? '.env',
+  }) : path = path == null || path == '' ? '.env' : path,
        requireEnvFile = requireEnvFile ?? false;
 }
 

--- a/packages/envied/test/envy_test.dart
+++ b/packages/envied/test/envy_test.dart
@@ -17,6 +17,11 @@ void main() {
       expect(envied.path, '.env.test');
     });
 
+    test('Empty path', () {
+      final envied = Envied(path: '');
+      expect(envied.path, '.env');
+    });
+
     test('Specified inheritFrom', () {
       final envied = Envied(inheritFrom: ['.env.defaults']);
       expect(envied.inheritFrom, ['.env.defaults']);

--- a/packages/envied/test/envy_test.dart
+++ b/packages/envied/test/envy_test.dart
@@ -6,6 +6,7 @@ void main() {
     test('Empty constructor', () {
       final envied = Envied();
       expect(envied.path, '.env');
+      expect(envied.inheritFrom, isEmpty);
       expect(envied.requireEnvFile, false);
       expect(envied.obfuscate, false);
       expect(envied.useConstantCase, isFalse);
@@ -14,6 +15,11 @@ void main() {
     test('Specified path', () {
       final envied = Envied(path: '.env.test');
       expect(envied.path, '.env.test');
+    });
+
+    test('Specified inheritFrom', () {
+      final envied = Envied(inheritFrom: ['.env.defaults']);
+      expect(envied.inheritFrom, ['.env.defaults']);
     });
 
     test('Specified useConstantCase', () {

--- a/packages/envied_generator/lib/src/generator.dart
+++ b/packages/envied_generator/lib/src/generator.dart
@@ -76,15 +76,10 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
     return '$ignore\n$generatedClassesAltogether';
   }
 
-  String _generatedFrom(Iterable<ConstantReader> annotations) {
-    final LinkedHashSet<String> paths = LinkedHashSet<String>();
-
-    for (final ConstantReader annotation in annotations) {
-      paths.addAll(_pathsForAnnotation(annotation));
-    }
-
-    return paths.join(', ');
-  }
+  String _generatedFrom(Iterable<ConstantReader> annotations) =>
+      LinkedHashSet<String>.of(
+        annotations.expand(_pathsForAnnotation),
+      ).join(', ');
 
   Future<String> _generateClassForEnviedAnnotation({
     required ClassElement element,

--- a/packages/envied_generator/lib/src/generator.dart
+++ b/packages/envied_generator/lib/src/generator.dart
@@ -149,8 +149,9 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
   }
 
   String _resolvePath(ConstantReader annotation) {
-    final String annotationPath =
-        annotation.read('path').literalValue as String? ?? '.env';
+    final String annotationPath = _defaultPath(
+      annotation.read('path').literalValue as String?,
+    );
 
     if (_buildOptions.override != true) {
       return annotationPath;
@@ -176,6 +177,9 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
 
     return _nonEmpty(_buildOptions.path) ?? annotationPath;
   }
+
+  static String _defaultPath(String? path) =>
+      path == null || path.isEmpty ? '.env' : path;
 
   List<String> _inheritFrom(ConstantReader annotation) => annotation
       .read('inheritFrom')

--- a/packages/envied_generator/lib/src/generator.dart
+++ b/packages/envied_generator/lib/src/generator.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: deprecated_member_use
 
+import 'dart:collection' show LinkedHashSet;
 import 'dart:io' show Platform;
 
 import 'package:analyzer/dart/constant/value.dart';
@@ -76,13 +77,10 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
   }
 
   String _generatedFrom(Iterable<ConstantReader> annotations) {
-    final List<String> paths = <String>[];
+    final LinkedHashSet<String> paths = LinkedHashSet<String>();
 
     for (final ConstantReader annotation in annotations) {
-      final String path = _resolvePath(annotation);
-      if (!paths.contains(path)) {
-        paths.add(path);
-      }
+      paths.addAll(_pathsForAnnotation(annotation));
     }
 
     return paths.join(', ');
@@ -96,6 +94,7 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
   }) async {
     final Envied config = Envied(
       path: _resolvePath(annotation),
+      inheritFrom: _inheritFrom(annotation),
       requireEnvFile:
           annotation.read('requireEnvFile').literalValue as bool? ?? false,
       name: annotation.read('name').literalValue as String?,
@@ -111,13 +110,14 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
       randomSeed: annotation.read('randomSeed').literalValue as int?,
     );
 
-    final Map<String, EnvVal> envs = await loadEnvs(config.path, (
-      String error,
-    ) {
-      if (config.requireEnvFile) {
-        throw InvalidGenerationSourceError(error, element: element);
-      }
-    });
+    final Map<String, EnvVal> envs = await loadEnvsFromPaths(
+      <String>[...config.inheritFrom, config.path],
+      (String error) {
+        if (config.requireEnvFile) {
+          throw InvalidGenerationSourceError(error, element: element);
+        }
+      },
+    );
 
     final DartEmitter emitter = DartEmitter(useNullSafetySyntax: true);
 
@@ -175,6 +175,18 @@ final class EnviedGenerator extends GeneratorForAnnotation<Envied> {
     }
 
     return _nonEmpty(_buildOptions.path) ?? annotationPath;
+  }
+
+  List<String> _inheritFrom(ConstantReader annotation) => annotation
+      .read('inheritFrom')
+      .listValue
+      .map((DartObject value) => value.toStringValue())
+      .whereType<String>()
+      .toList(growable: false);
+
+  Iterable<String> _pathsForAnnotation(ConstantReader annotation) sync* {
+    yield* _inheritFrom(annotation);
+    yield _resolvePath(annotation);
   }
 
   static String? _nonEmpty(String? value) =>

--- a/packages/envied_generator/lib/src/load_envs.dart
+++ b/packages/envied_generator/lib/src/load_envs.dart
@@ -10,8 +10,31 @@ import 'package:envied_generator/src/parser.dart';
 /// [onError] function.
 Future<Map<String, EnvVal>> loadEnvs(
   String path,
-  Function(String) onError,
+  void Function(String) onError,
+) => loadEnvsFromPaths(<String>[path], onError);
+
+/// Load and merge environment variables from [paths].
+///
+/// Files are parsed in order. Later files override earlier files, while
+/// duplicate keys within a single file keep the first parsed value.
+Future<Map<String, EnvVal>> loadEnvsFromPaths(
+  Iterable<String> paths,
+  void Function(String) onError,
 ) async {
+  final Map<String, EnvVal> envs = <String, EnvVal>{};
+
+  for (final String path in paths) {
+    envs.addAll(await _loadEnv(path, onError, env: envs));
+  }
+
+  return envs;
+}
+
+Future<Map<String, EnvVal>> _loadEnv(
+  String path,
+  void Function(String) onError, {
+  required Map<String, EnvVal> env,
+}) async {
   final File file = File.fromUri(Uri.file(path));
 
   final List<String> lines = [];
@@ -21,5 +44,5 @@ Future<Map<String, EnvVal>> loadEnvs(
     onError("Environment variable file doesn't exist at `$path`.");
   }
 
-  return Parser.parse(lines);
+  return Parser.parse(lines, env: env);
 }

--- a/packages/envied_generator/lib/src/load_envs.dart
+++ b/packages/envied_generator/lib/src/load_envs.dart
@@ -21,7 +21,7 @@ Future<Map<String, EnvVal>> loadEnvsFromPaths(
   Iterable<String> paths,
   void Function(String) onError,
 ) async {
-  final Map<String, EnvVal> envs = <String, EnvVal>{};
+  final Map<String, EnvVal> envs = {};
 
   for (final String path in paths) {
     envs.addAll(await _loadEnv(path, onError, env: envs));

--- a/packages/envied_generator/lib/src/parser.dart
+++ b/packages/envied_generator/lib/src/parser.dart
@@ -19,12 +19,22 @@ final class Parser {
 
   /// Creates a [Map](dart:core).
   /// Duplicate keys are silently discarded.
-  static Map<String, EnvVal> parse(Iterable<String> lines) {
+  static Map<String, EnvVal> parse(
+    Iterable<String> lines, {
+    Map<String, EnvVal> env = const {},
+  }) {
     final Map<String, EnvVal> out = {};
+    final Map<String, EnvVal> interpolationEnv = Map.of(env);
+
     for (final String line in lines) {
-      final Map<String, EnvVal> kv = parseOne(line, env: out);
+      final Map<String, EnvVal> kv = parseOne(line, env: interpolationEnv);
       if (kv.isNotEmpty) {
-        out.putIfAbsent(kv.keys.single, () => kv.values.single);
+        final String key = kv.keys.single;
+        if (!out.containsKey(key)) {
+          final EnvVal value = kv.values.single;
+          out[key] = value;
+          interpolationEnv[key] = value;
+        }
       }
     }
     return out;

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   analyzer: ">=8.0.0 <14.0.0"
   build: ^4.0.3
   code_builder: ^4.11.0
-  envied: ^1.3.3
+  envied: ^1.3.3  # TODO(@techouse) make sure to update to the very latest before release
   equatable: ^2.0.7
   recase: ^4.1.0
   source_gen: ^4.1.1

--- a/packages/envied_generator/test/.env.inheritance_alt_child
+++ b/packages/envied_generator/test/.env.inheritance_alt_child
@@ -1,0 +1,2 @@
+baseValue=alt-child
+sharedValue=alt-child

--- a/packages/envied_generator/test/.env.inheritance_alt_defaults
+++ b/packages/envied_generator/test/.env.inheritance_alt_defaults
@@ -1,0 +1,2 @@
+baseValue=alt-base
+sharedValue=alt-defaults

--- a/packages/envied_generator/test/.env.inheritance_child
+++ b/packages/envied_generator/test/.env.inheritance_child
@@ -1,0 +1,7 @@
+childValue=child
+overrideValue=child
+sharedValue=child
+interpolatedValue=$baseValue-$childValue
+interpolatedOverrideValue=$overrideValue
+duplicateValue=child-first
+duplicateValue=child-second

--- a/packages/envied_generator/test/.env.inheritance_defaults
+++ b/packages/envied_generator/test/.env.inheritance_defaults
@@ -1,0 +1,3 @@
+baseValue=base
+overrideValue=base
+sharedValue=defaults

--- a/packages/envied_generator/test/.env.inheritance_middle
+++ b/packages/envied_generator/test/.env.inheritance_middle
@@ -1,0 +1,2 @@
+middleValue=middle
+overrideValue=middle

--- a/packages/envied_generator/test/envy_generator_test.dart
+++ b/packages/envied_generator/test/envy_generator_test.dart
@@ -32,6 +32,14 @@ Future<void> main() async {
   testAnnotatedElements(
     await initializeLibraryReaderForDirectory(
       'test/src',
+      'generator_tests_with_inheritance.dart',
+    ),
+    EnviedGenerator(const BuildOptions()),
+  );
+
+  testAnnotatedElements(
+    await initializeLibraryReaderForDirectory(
+      'test/src',
       'generator_tests_with_path_overrides.dart',
     ),
     EnviedGenerator(

--- a/packages/envied_generator/test/src/generator_tests.dart
+++ b/packages/envied_generator/test/src/generator_tests.dart
@@ -20,6 +20,15 @@ final class _Env0 {}
 @Envied()
 abstract class Env0 {}
 
+@ShouldGenerate(r'''
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// generated_from: .env
+final class _Env0b {}
+''')
+@Envied(path: '')
+abstract class Env0b {}
+
 @ShouldThrow(
   "Environment variable file doesn't exist at `${String.fromEnvironment('ENV_PATH', defaultValue: '.env')}`.",
 )

--- a/packages/envied_generator/test/src/generator_tests_with_inheritance.dart
+++ b/packages/envied_generator/test/src/generator_tests_with_inheritance.dart
@@ -1,0 +1,112 @@
+// ignore_for_file: unnecessary_nullable_for_final_variable_declarations
+
+import 'package:envied/envied.dart';
+import 'package:source_gen_test/annotations.dart';
+
+@ShouldGenerate(r'''
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// generated_from: test/.env.inheritance_defaults, test/.env.inheritance_middle, test/.env.inheritance_child
+final class _EnvInheritance {
+  static const String baseValue = 'base';
+
+  static const String middleValue = 'middle';
+
+  static const String childValue = 'child';
+
+  static const String overrideValue = 'child';
+
+  static const String interpolatedValue = 'base-child';
+
+  static const String interpolatedOverrideValue = 'child';
+
+  static const String duplicateValue = 'child-first';
+}
+''')
+@Envied(
+  path: 'test/.env.inheritance_child',
+  inheritFrom: [
+    'test/.env.inheritance_defaults',
+    'test/.env.inheritance_middle',
+  ],
+)
+abstract class EnvInheritance {
+  @EnviedField()
+  static const String? baseValue = null;
+  @EnviedField()
+  static const String? middleValue = null;
+  @EnviedField()
+  static const String? childValue = null;
+  @EnviedField()
+  static const String? overrideValue = null;
+  @EnviedField()
+  static const String? interpolatedValue = null;
+  @EnviedField()
+  static const String? interpolatedOverrideValue = null;
+  @EnviedField()
+  static const String? duplicateValue = null;
+}
+
+@ShouldGenerate(r'''
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// generated_from: test/.env.inheritance_missing, test/.env.inheritance_child
+final class _EnvInheritanceWithMissingOptional {
+  static const String childValue = 'child';
+}
+''')
+@Envied(
+  path: 'test/.env.inheritance_child',
+  inheritFrom: ['test/.env.inheritance_missing'],
+)
+abstract class EnvInheritanceWithMissingOptional {
+  @EnviedField()
+  static const String? childValue = null;
+}
+
+@ShouldThrow(
+  "Environment variable file doesn't exist at `test/.env.inheritance_missing`.",
+)
+@Envied(
+  path: 'test/.env.inheritance_child',
+  inheritFrom: ['test/.env.inheritance_missing'],
+  requireEnvFile: true,
+)
+abstract class EnvInheritanceWithMissingRequired {}
+
+@ShouldGenerate(r'''
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// generated_from: test/.env.inheritance_defaults, test/.env.inheritance_child, test/.env.inheritance_alt_defaults, test/.env.inheritance_alt_child
+final class _DevelopmentEnv implements EnvInheritanceMultiple {
+  @override
+  final String baseValue = 'base';
+
+  @override
+  final String sharedValue = 'child';
+}
+
+final class _ProductionEnv implements EnvInheritanceMultiple {
+  @override
+  final String baseValue = 'alt-child';
+
+  @override
+  final String sharedValue = 'alt-child';
+}
+''')
+@Envied(
+  path: 'test/.env.inheritance_child',
+  inheritFrom: ['test/.env.inheritance_defaults'],
+  name: 'DevelopmentEnv',
+)
+@Envied(
+  path: 'test/.env.inheritance_alt_child',
+  inheritFrom: ['test/.env.inheritance_alt_defaults'],
+  name: 'ProductionEnv',
+)
+abstract class EnvInheritanceMultiple {
+  @EnviedField()
+  final String? baseValue = null;
+  @EnviedField()
+  final String? sharedValue = null;
+}


### PR DESCRIPTION
This pull request introduces support for environment file inheritance in the Envied package, allowing users to specify multiple `.env` files whose values are loaded and merged in order. The changes include updates to the `Envied` annotation, enhancements to the environment loading logic, and comprehensive tests and documentation to cover the new feature.

**Environment inheritance feature:**

- Added a new `inheritFrom` parameter to the `Envied` annotation, allowing users to specify an ordered list of `.env` files to be loaded before the primary file, with later files overriding earlier values. (`packages/envied/lib/src/envied_base.dart`, `packages/envied_generator/lib/src/generator.dart`) [[1]](diffhunk://#diff-2840575a98cec94a77ff8dd956d3a05f02b8e0881ad337cd0f73258f0621391dR12-R17) [[2]](diffhunk://#diff-2840575a98cec94a77ff8dd956d3a05f02b8e0881ad337cd0f73258f0621391dR109) [[3]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caL42-R51) [[4]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caL69-R68) [[5]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caR78-R100) [[6]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caL109-R123) [[7]](diffhunk://#diff-70739d136f7c66633d926b87532dbcad7e1ba0cf033df53d47945e416b06d8caR154-R173)

- Updated the environment variable loading logic to support merging values from multiple files, preserving the correct override order and supporting variable interpolation across inherited files. (`packages/envied_generator/lib/src/load_envs.dart`, `packages/envied_generator/lib/src/parser.dart`) [[1]](diffhunk://#diff-4082e34afa3805d610580778a46356bf2acca77e053c28db84f7a25ed801d57bL11-R35) [[2]](diffhunk://#diff-4082e34afa3805d610580778a46356bf2acca77e053c28db84f7a25ed801d57bL24-R45) [[3]](diffhunk://#diff-f323253b8575b959a00eb4e09fa11d80d587925e0a203ef0033a7ec8d5188ac7L22-R37)

**Documentation improvements:**

- Extended the README with a new section and example for environment inheritance, explaining usage and override behavior. (`packages/envied/README.md`) [[1]](diffhunk://#diff-4a011b1a508b3a235167e0553e65fc6aa465c07b699440bb2b0113a83906991fR39) [[2]](diffhunk://#diff-4a011b1a508b3a235167e0553e65fc6aa465c07b699440bb2b0113a83906991fR296-R330)

**Testing and validation:**

- Added new and updated tests to verify the behavior of the `inheritFrom` parameter, including edge cases with missing files and multiple inheritance scenarios. (`packages/envied/test/envy_test.dart`, `packages/envied_generator/test/envy_generator_test.dart`, `packages/envied_generator/test/src/generator_tests_with_inheritance.dart`, and new test `.env` files) [[1]](diffhunk://#diff-23e417b942877f8a1fe0b30292720477c09fd7cdf3a37e27eb101d7b4cb56a8bR9) [[2]](diffhunk://#diff-23e417b942877f8a1fe0b30292720477c09fd7cdf3a37e27eb101d7b4cb56a8bR20-R29) [[3]](diffhunk://#diff-ca5077f67806371f7ea35bda179e4b5e294aa6c1f0b7ddcd6bbfbf3bc0b385c5R31-R38) [[4]](diffhunk://#diff-c4c02dccf70f6fc863c51214d90093f80679c858f8cb61c7c4f880ef850e41f9R1-R112) [[5]](diffhunk://#diff-e69fde0da7076745a4a166c313aa97346ba71de48ebc705253301e241471a380R1-R2) [[6]](diffhunk://#diff-ae181e97425b40bb03c38346c928de989b33d4b532bc44d97d9e47ee8a68df5aR1-R2) [[7]](diffhunk://#diff-18dbab966770046aeddf8615c402360d2f131dffc661741a8c5300284d412c03R1-R7) [[8]](diffhunk://#diff-87492f439436b181c7e9c168668f85949efe58f41462c8d61e8089efa03b134cR1-R3) [[9]](diffhunk://#diff-d3dd39e98e7d3042aa5ffd45d9dde766fbcaf02eb0b7055d9f9ff53cbbb8759aR1-R2)

**Minor improvements:**

- Improved handling of empty `path` values in the `Envied` annotation to default to `.env`. (`packages/envied/lib/src/envied_base.dart`, `packages/envied_generator/lib/src/generator.dart`, `packages/envied_generator/test/src/generator_tests.dart`) [[1]](diffhunk://#diff-2840575a98cec94a77ff8dd956d3a05f02b8e0881ad337cd0f73258f0621391dL112-R119) [[2]](diffhunk://#diff-9164cd585484b603acaa9d4a9ff274c15b2b83134c221af70ab9e008c372de61R23-R31)

**Changelog update:**

- Updated the changelog to reflect the addition of the environment inheritance feature. (`CHANGELOG.md`)