### PR TITLE
chore: release v1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2026-05-10
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+### Packages with other changes:
+
+### Packages with other changes:
+
+ - [`envied` - `v1.3.5`](#envied---v135)
+ - [`envied_generator` - `v1.3.5`](#enviedgenerator---v135)
+
+#### `envied` - `v1.3.5`
+
+ - **FEAT**: add `pathOverrides` support for Envied annotations (#183)
+ - **FEAT**: add `.env` inheritance support in Envied and EnviedGenerator (#190)
+ - **CHORE**: add support for `analyzer` 13.0.0 (#187)
+
+#### `envied_generator` - `v1.3.5`
+
+ - **FEAT**: add `pathOverrides` support for Envied annotations (#183)
+ - **FEAT**: add `.env` inheritance support in Envied and EnviedGenerator (#190)
+ - **CHORE**: add support for `analyzer` 13.0.0 (#187)
+
 ## 2026-03-22
 
 ### Changes

--- a/packages/envied/CHANGELOG.md
+++ b/packages/envied/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.5
+
+- **FEAT**: add `pathOverrides` support for Envied annotations (#183)
+- **FEAT**: add `.env` inheritance support in Envied and EnviedGenerator (#190)
+- **CHORE**: add support for `analyzer` 13.0.0 (#187)
+
 ## 1.3.4
 
 - **CHORE**: add support for `analyzer` 12.0.0 (#179)

--- a/packages/envied/pubspec.yaml
+++ b/packages/envied/pubspec.yaml
@@ -1,7 +1,7 @@
 name: envied
 resolution: workspace
 description: Explicitly reads environment variables into a dart file from a .env file for more security and faster start up times.
-version: 1.3.4
+version: 1.3.5
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 

--- a/packages/envied_generator/CHANGELOG.md
+++ b/packages/envied_generator/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.5
+
+- **FEAT**: add `pathOverrides` support for Envied annotations (#183)
+- **FEAT**: add `.env` inheritance support in Envied and EnviedGenerator (#190)
+- **CHORE**: add support for `analyzer` 13.0.0 (#187)
+
 ## 1.3.4
 
 - **CHORE**: add support for `analyzer` 12.0.0 (#179)

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -1,7 +1,7 @@
 name: envied_generator
 resolution: workspace
 description: Generator for the Envied package. See https://pub.dev/packages/envied.
-version: 1.3.4
+version: 1.3.5
 repository: https://github.com/petercinibulk/envied
 homepage: https://github.com/petercinibulk/envied
 
@@ -12,7 +12,7 @@ dependencies:
   analyzer: ">=8.0.0 <14.0.0"
   build: ^4.0.3
   code_builder: ^4.11.0
-  envied: ^1.3.3  # TODO(@techouse) make sure to update to the very latest before release
+  envied: ^1.3.5
   equatable: ^2.0.7
   recase: ^4.1.0
   source_gen: ^4.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ workspace:
   - examples/envied_example
 
 dev_dependencies:
-  melos: ^7.5.1
+  melos: ^7.7.0
   path: ^1.9.1
   yaml: ^3.1.3
 


### PR DESCRIPTION
## 2026-05-10

### Changes

---

Packages with breaking changes:

 - There are no breaking changes in this release.

### Packages with other changes:

### Packages with other changes:

 - [`envied` - `v1.3.5`](#envied---v135)
 - [`envied_generator` - `v1.3.5`](#enviedgenerator---v135)

#### `envied` - `v1.3.5`

 - **FEAT**: add `pathOverrides` support for Envied annotations (#183)
 - **FEAT**: add `.env` inheritance support in Envied and EnviedGenerator (#190)
 - **CHORE**: add support for `analyzer` 13.0.0 (#187)

#### `envied_generator` - `v1.3.5`

 - **FEAT**: add `pathOverrides` support for Envied annotations (#183)
 - **FEAT**: add `.env` inheritance support in Envied and EnviedGenerator (#190)
 - **CHORE**: add support for `analyzer` 13.0.0 (#187)