### PR TITLE
fix: load hidden environment files on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,11 +131,32 @@ jobs:
           else
             echo "PUBLISH_DRY_RUN=0" >> $GITHUB_OUTPUT
           fi
+  windows_env_files:
+    name: "Windows env files"
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@v7
+      - id: setup_dart
+        name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - id: dependencies
+        name: Get dependencies
+        run: dart pub get
+      - id: test
+        name: Test hidden env file loading
+        working-directory: packages/envied_generator
+        run: dart test test/hidden_directory_build_runner_test.dart
   publish_dry_run:
     name: "Publish [DRY RUN]"
     needs:
       - minimum_dart
       - test
+      - windows_env_files
     runs-on: ubuntu-latest
     env:
       SHOULD_RUN: ${{ needs.test.outputs.PUBLISH_DRY_RUN }}

--- a/packages/envied_generator/lib/src/load_envs.dart
+++ b/packages/envied_generator/lib/src/load_envs.dart
@@ -4,7 +4,12 @@ import 'dart:io' show Directory, File;
 import 'package:build/build.dart';
 import 'package:envied_generator/src/env_val.dart';
 import 'package:envied_generator/src/parser.dart';
-import 'package:package_config/package_config.dart' show findPackageConfig;
+import 'package:package_config/package_config.dart'
+    show PackageConfig, findPackageConfig;
+
+final Future<PackageConfig?> _packageConfig = findPackageConfig(
+  Directory.current,
+);
 
 /// Load the environment variables from the supplied [path],
 /// using the `dotenv` parser.
@@ -97,8 +102,7 @@ bool _hasHiddenPathSegment(AssetId assetId) =>
     assetId.pathSegments.any((String segment) => segment.startsWith('.'));
 
 Future<File?> _packageFileForAsset(AssetId assetId) async {
-  final packageConfig = await findPackageConfig(Directory.current);
-  final package = packageConfig?[assetId.package];
+  final package = (await _packageConfig)?[assetId.package];
   if (package == null || package.root.scheme != 'file') {
     return null;
   }

--- a/packages/envied_generator/lib/src/load_envs.dart
+++ b/packages/envied_generator/lib/src/load_envs.dart
@@ -1,10 +1,10 @@
 import 'dart:convert' show LineSplitter;
-import 'dart:io' show File;
-import 'dart:isolate' show Isolate;
+import 'dart:io' show Directory, File;
 
 import 'package:build/build.dart';
 import 'package:envied_generator/src/env_val.dart';
 import 'package:envied_generator/src/parser.dart';
+import 'package:package_config/package_config.dart' show findPackageConfig;
 
 /// Load the environment variables from the supplied [path],
 /// using the `dotenv` parser.
@@ -97,13 +97,11 @@ bool _hasHiddenPathSegment(AssetId assetId) =>
     assetId.pathSegments.any((String segment) => segment.startsWith('.'));
 
 Future<File?> _packageFileForAsset(AssetId assetId) async {
-  final Uri? packageLibUri = await Isolate.resolvePackageUri(
-    Uri(scheme: 'package', path: '${assetId.package}/'),
-  );
-  if (packageLibUri == null || packageLibUri.scheme != 'file') {
+  final packageConfig = await findPackageConfig(Directory.current);
+  final package = packageConfig?[assetId.package];
+  if (package == null || package.root.scheme != 'file') {
     return null;
   }
 
-  final Uri packageRootUri = packageLibUri.resolve('../');
-  return File.fromUri(packageRootUri.resolve(assetId.path));
+  return File.fromUri(package.root.resolve(assetId.path));
 }

--- a/packages/envied_generator/pubspec.yaml
+++ b/packages/envied_generator/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   code_builder: ^4.11.0
   envied: ^1.3.7
   equatable: ^2.0.7
+  package_config: ^2.2.0
   recase: ^4.1.0
   source_gen: ^4.1.1
 

--- a/packages/envied_generator/test/hidden_directory_build_runner_test.dart
+++ b/packages/envied_generator/test/hidden_directory_build_runner_test.dart
@@ -5,81 +5,83 @@ import 'dart:isolate';
 import 'package:test/test.dart';
 
 void main() {
-  test(
-    'build_runner loads an env file from a hidden directory without build.yaml',
-    () async {
-      final Uri generatorLibUri = (await Isolate.resolvePackageUri(
-        Uri.parse('package:envied_generator/'),
-      ))!;
-      final Directory generatorPackage = Directory.fromUri(
-        generatorLibUri.resolve('../'),
+  group('build_runner loads hidden env files without build.yaml', () {
+    for (final String envPath in <String>['.env', '.env/.env.dev']) {
+      test(
+        envPath,
+        () => _expectBuildSucceeds(envPath),
+        timeout: const Timeout(Duration(minutes: 2)),
       );
-      final Directory enviedPackage = Directory.fromUri(
-        generatorPackage.uri.resolve('../envied/'),
-      );
-      final Directory fixture = await Directory.systemTemp.createTemp(
-        'envied_hidden_directory_',
-      );
+    }
+  });
+}
 
-      try {
-        await _writeFixture(
-          fixture,
-          generatorPackage: generatorPackage,
-          enviedPackage: enviedPackage,
-        );
-
-        // The workspace bootstrap has already populated the pub cache. Resolve the
-        // temporary fixture offline so this test does not depend on network access.
-        final ProcessResult pubGet = await Process.run(
-          Platform.resolvedExecutable,
-          <String>['pub', 'get', '--offline'],
-          workingDirectory: fixture.path,
-        );
-        expect(
-          pubGet.exitCode,
-          0,
-          reason: 'dart pub get failed:\n${pubGet.stdout}\n${pubGet.stderr}',
-        );
-
-        final ProcessResult build = await Process.run(
-          Platform.resolvedExecutable,
-          <String>[
-            'run',
-            'build_runner',
-            'build',
-            '--delete-conflicting-outputs',
-          ],
-          workingDirectory: fixture.path,
-        );
-        expect(
-          build.exitCode,
-          0,
-          reason:
-              'build_runner failed without build.yaml:\n'
-              '${build.stdout}\n${build.stderr}',
-        );
-
-        final String generated = await File(
-          '${fixture.path}/lib/app_env.g.dart',
-        ).readAsString();
-        expect(generated, contains('hidden-directory-secret'));
-      } finally {
-        await fixture.delete(recursive: true);
-      }
-    },
-    timeout: const Timeout(Duration(minutes: 2)),
+Future<void> _expectBuildSucceeds(String envPath) async {
+  final Uri generatorLibUri = (await Isolate.resolvePackageUri(
+    Uri.parse('package:envied_generator/'),
+  ))!;
+  final Directory generatorPackage = Directory.fromUri(
+    generatorLibUri.resolve('../'),
   );
+  final Directory enviedPackage = Directory.fromUri(
+    generatorPackage.uri.resolve('../envied/'),
+  );
+  final Directory fixture = await Directory.systemTemp.createTemp(
+    'envied_hidden_env_',
+  );
+
+  try {
+    await _writeFixture(
+      fixture,
+      envPath: envPath,
+      generatorPackage: generatorPackage,
+      enviedPackage: enviedPackage,
+    );
+
+    // The workspace bootstrap has already populated the pub cache. Resolve the
+    // temporary fixture offline so this test does not depend on network access.
+    final ProcessResult pubGet = await Process.run(
+      Platform.resolvedExecutable,
+      <String>['pub', 'get', '--offline'],
+      workingDirectory: fixture.path,
+    );
+    expect(
+      pubGet.exitCode,
+      0,
+      reason: 'dart pub get failed:\n${pubGet.stdout}\n${pubGet.stderr}',
+    );
+
+    final ProcessResult build = await Process.run(
+      Platform.resolvedExecutable,
+      <String>['run', 'build_runner', 'build'],
+      workingDirectory: fixture.path,
+    );
+    expect(
+      build.exitCode,
+      0,
+      reason:
+          'build_runner failed for `$envPath` without build.yaml:\n'
+          '${build.stdout}\n${build.stderr}',
+    );
+
+    final String generated = await File.fromUri(
+      fixture.uri.resolve('lib/app_env.g.dart'),
+    ).readAsString();
+    expect(generated, contains('hidden-env-secret'));
+  } finally {
+    await fixture.delete(recursive: true);
+  }
 }
 
 Future<void> _writeFixture(
   Directory fixture, {
+  required String envPath,
   required Directory generatorPackage,
   required Directory enviedPackage,
 }) async {
-  await Directory('${fixture.path}/lib').create(recursive: true);
-  await Directory('${fixture.path}/.env').create(recursive: true);
+  await Directory.fromUri(fixture.uri.resolve('lib/')).create(recursive: true);
 
-  await File('${fixture.path}/pubspec.yaml').writeAsString('''
+  await File.fromUri(fixture.uri.resolve('pubspec.yaml')).writeAsString('''
 name: envied_hidden_directory_fixture
 publish_to: none
 
@@ -98,15 +100,15 @@ dependency_overrides:
   envied:
     path: ${jsonEncode(enviedPackage.path)}
 ''');
-  await File(
-    '${fixture.path}/.env/.env.dev',
-  ).writeAsString('SECRET_KEY=hidden-directory-secret\n');
-  await File('${fixture.path}/lib/app_env.dart').writeAsString(r'''
+  final File envFile = File.fromUri(fixture.uri.resolve(envPath));
+  await envFile.parent.create(recursive: true);
+  await envFile.writeAsString('SECRET_KEY=hidden-env-secret\n');
+  await File.fromUri(fixture.uri.resolve('lib/app_env.dart')).writeAsString('''
 import 'package:envied/envied.dart';
 
 part 'app_env.g.dart';
 
-@Envied(path: '.env/.env.dev', requireEnvFile: true)
+@Envied(path: ${jsonEncode(envPath)}, requireEnvFile: true)
 abstract class AppEnv {
   @EnviedField(varName: 'SECRET_KEY')
   static const String secretKey = _AppEnv.secretKey;


### PR DESCRIPTION
## Summary

- Resolve hidden environment files through the package configuration instead of `Isolate.resolvePackageUri`.
- Add end-to-end coverage for both `.env` and `.env/.env.dev`.
- Run the hidden-file regression tests on Windows and gate publish dry-runs on them.

## Problem

The filesystem fallback added in #198 restored hidden environment-file support on Linux and macOS, but still failed under build-runner’s AOT process on Windows.

Although the files existed, `Isolate.resolvePackageUri` could not resolve the consumer package root. Envied consequently reported:

```text
Environment variable file doesn't exist at `.env`.
```

Pinning `envied_generator` to 1.3.5 avoided the regression because that version read relative paths directly from the filesystem.

## Solution

Use `findPackageConfig(Directory.current)` to load `.dart_tool/package_config.json`, locate the package identified by `AssetId.package`, and resolve the environment path against its declared package root.

This approach:

- Works under build-runner AOT on Windows.
- Preserves package-relative resolution in Dart workspaces.
- Retains the Dart 3.9 minimum SDK through `package_config` 2.2.x.
- Continues restricting filesystem fallback to hidden paths.

## Testing

- Added real build-runner fixtures for:
  - `.env`
  - `.env/.env.dev`
- Added a focused `windows-latest` CI job.
- All 171 `envied_generator` tests pass locally.
- Dart analysis passes.
- Windows, Ubuntu, and minimum Dart 3.9 GitHub Actions checks pass.

Fixes #200.